### PR TITLE
Power budget tool improvements

### DIFF
--- a/apps/web/src/components/Workbench/PowerBudgetInsight.tsx
+++ b/apps/web/src/components/Workbench/PowerBudgetInsight.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { WorkbenchRow } from './WorkbenchTable';
+import { Jack } from '../../utils/transformers';
 
 interface PowerBudgetInsightProps {
   rows: WorkbenchRow[];
@@ -9,47 +10,169 @@ interface PowerConsumer {
   manufacturer: string;
   model: string;
   current_ma: number | null;
+  voltage: string | null;
+  polarity: string | null;
+  connector_type: string | null;
 }
 
-interface PowerSupply {
+interface PowerSupplyInfo {
   manufacturer: string;
   model: string;
   total_current_ma: number | null;
+  total_output_count: number | null;
+  isolated_output_count: number | null;
+  supply_type: string | null;
+  available_voltages: string | null;
+  mounting_type: string | null;
+  output_jacks: Jack[];
 }
 
-function getPowerConsumption(row: WorkbenchRow): number | null {
-  const powerJack = row.jacks.find(j => j.category === 'power' && j.direction === 'input');
-  return powerJack?.current_ma ?? null;
+function getPowerInputJack(row: WorkbenchRow): Jack | undefined {
+  return row.jacks.find(j => j.category === 'power' && j.direction === 'input');
 }
 
-function getPowerCapacity(row: WorkbenchRow): number | null {
-  return (row.detail.total_current_ma as number) ?? null;
+function getPowerOutputJacks(row: WorkbenchRow): Jack[] {
+  return row.jacks.filter(j => j.category === 'power' && j.direction === 'output');
 }
 
 function formatMa(ma: number): string {
   return `${ma.toLocaleString()}mA`;
 }
 
+/** Find the majority polarity among supply output jacks */
+function getMajorityPolarity(jacks: Jack[]): string | null {
+  const counts: Record<string, number> = {};
+  for (const j of jacks) {
+    if (j.polarity) {
+      counts[j.polarity] = (counts[j.polarity] || 0) + 1;
+    }
+  }
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [pol, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      best = pol;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** Find the majority connector type among supply output jacks */
+function getMajorityConnector(jacks: Jack[]): string | null {
+  const counts: Record<string, number> = {};
+  for (const j of jacks) {
+    if (j.connector_type) {
+      counts[j.connector_type] = (counts[j.connector_type] || 0) + 1;
+    }
+  }
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [ct, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      best = ct;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+interface DaisyChainGroup {
+  voltage: string;
+  polarity: string;
+  connector_type: string;
+  consumers: PowerConsumer[];
+  combined_ma: number;
+  max_output_ma: number | null;
+}
+
+/**
+ * When the supply has fewer outputs than pedals, identify groups of
+ * electrically compatible pedals that could share an output via daisy-chain.
+ */
+function computeDaisyChainGroups(
+  consumers: PowerConsumer[],
+  outputJacks: Jack[],
+): DaisyChainGroup[] {
+  // Only consumers with full known power specs can be grouped
+  const eligible = consumers.filter(
+    c => c.current_ma != null && c.voltage != null && c.polarity != null && c.connector_type != null,
+  );
+
+  // Group by (voltage, polarity, connector_type)
+  const groupMap = new Map<string, PowerConsumer[]>();
+  for (const c of eligible) {
+    const key = `${c.voltage}|${c.polarity}|${c.connector_type}`;
+    const arr = groupMap.get(key);
+    if (arr) arr.push(c);
+    else groupMap.set(key, [c]);
+  }
+
+  const groups: DaisyChainGroup[] = [];
+  for (const [key, members] of Array.from(groupMap)) {
+    if (members.length < 2) continue; // need at least 2 to daisy-chain
+    const [voltage, polarity, connector_type] = key.split('|');
+    const combinedMa = members.reduce((sum: number, c: PowerConsumer) => sum + (c.current_ma as number), 0);
+
+    // Find the highest-capacity output jack that matches this voltage
+    const matchingOutputs = outputJacks.filter(j => j.voltage === voltage);
+    const maxOutputMa = matchingOutputs.length > 0
+      ? Math.max(...matchingOutputs.map(j => j.current_ma ?? 0))
+      : null;
+
+    // Only suggest if combined draw fits within an output
+    if (maxOutputMa != null && combinedMa <= maxOutputMa) {
+      groups.push({ voltage, polarity, connector_type, consumers: members, combined_ma: combinedMa, max_output_ma: maxOutputMa });
+    }
+  }
+
+  return groups;
+}
+
+/** Build the "See all compatible power supplies" link URL */
+function buildSupplyLinkUrl(
+  totalDraw: number,
+  consumerCount: number,
+  highestDrawMa: number | null,
+  uniqueVoltages: string[],
+): string {
+  const params = new URLSearchParams();
+  if (totalDraw > 0) params.set('minCurrent', String(totalDraw));
+  if (consumerCount > 0) params.set('minOutputs', String(consumerCount));
+  if (highestDrawMa != null && highestDrawMa > 0) params.set('minOutputCurrent', String(highestDrawMa));
+  if (uniqueVoltages.length > 0) params.set('voltages', uniqueVoltages.join(','));
+  const qs = params.toString();
+  return qs ? `/power-supplies?${qs}` : '/power-supplies';
+}
+
 const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
   // Separate consumers from suppliers
   const consumers: PowerConsumer[] = [];
-  const supplies: PowerSupply[] = [];
+  const supplies: PowerSupplyInfo[] = [];
 
   for (const row of rows) {
     if (row.product_type === 'power_supply') {
       supplies.push({
         manufacturer: row.manufacturer,
         model: row.model,
-        total_current_ma: getPowerCapacity(row),
+        total_current_ma: (row.detail.total_current_ma as number) ?? null,
+        total_output_count: (row.detail.total_output_count as number) ?? null,
+        isolated_output_count: (row.detail.isolated_output_count as number) ?? null,
+        supply_type: (row.detail.supply_type as string) ?? null,
+        available_voltages: (row.detail.available_voltages as string) ?? null,
+        mounting_type: (row.detail.mounting_type as string) ?? null,
+        output_jacks: getPowerOutputJacks(row),
       });
     } else {
-      // Any non-PSU product with a power input jack is a consumer
-      const currentMa = getPowerConsumption(row);
-      if (currentMa != null || row.jacks.some(j => j.category === 'power' && j.direction === 'input')) {
+      const powerJack = getPowerInputJack(row);
+      if (powerJack || row.jacks.some(j => j.category === 'power' && j.direction === 'input')) {
         consumers.push({
           manufacturer: row.manufacturer,
           model: row.model,
-          current_ma: currentMa,
+          current_ma: powerJack?.current_ma ?? null,
+          voltage: powerJack?.voltage ?? null,
+          polarity: powerJack?.polarity ?? null,
+          connector_type: powerJack?.connector_type ?? null,
         });
       }
     }
@@ -64,10 +187,20 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
   const highestDraw = knownConsumers.length > 0
     ? knownConsumers.reduce((max, c) => (c.current_ma as number) > (max.current_ma as number) ? c : max)
     : null;
+  const highestDrawMa = highestDraw ? (highestDraw.current_ma as number) : null;
+
+  // Unique voltages needed
+  const uniqueVoltages = Array.from(
+    new Set(consumers.map(c => c.voltage).filter((v): v is string => v != null))
+  ).sort();
 
   const totalCapacity = supplies.reduce((sum, s) => sum + (s.total_current_ma ?? 0), 0);
   const hasSupply = supplies.length > 0;
   const knownSupplies = supplies.filter(s => s.total_current_ma != null);
+
+  // Combined supply stats
+  const totalOutputCount = supplies.reduce((sum, s) => sum + (s.total_output_count ?? 0), 0);
+  const allOutputJacks = supplies.flatMap(s => s.output_jacks);
 
   // Determine state
   let status: 'no-supply' | 'insufficient' | 'sufficient';
@@ -81,6 +214,98 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
 
   const headroom = totalCapacity - totalDraw;
   const headroomPct = totalCapacity > 0 ? Math.round((headroom / totalCapacity) * 100) : 0;
+
+  // Build smart link URL
+  const supplyLinkUrl = buildSupplyLinkUrl(totalDraw, consumers.length, highestDrawMa, uniqueVoltages);
+
+  // --- Warnings (only when a supply is present) ---
+  const warnings: React.ReactNode[] = [];
+
+  if (hasSupply) {
+    // 1. Output count warning
+    const outputDiff = totalOutputCount - consumers.length;
+    if (outputDiff < 0) {
+      // Fewer outputs than pedals
+      const daisyGroups = computeDaisyChainGroups(consumers, allOutputJacks);
+      warnings.push(
+        <div key="output-count" className="power-budget__warning power-budget__warning--warn">
+          <strong>Output count:</strong> You have {consumers.length} device{consumers.length !== 1 ? 's' : ''} but only {totalOutputCount} output{totalOutputCount !== 1 ? 's' : ''} ({Math.abs(outputDiff)} short).
+          {daisyGroups.length > 0 && (
+            <div className="power-budget__daisy-chain">
+              <div className="power-budget__daisy-chain-title">Possible daisy-chain groupings:</div>
+              {daisyGroups.map((g, i) => (
+                <div key={i} className="power-budget__daisy-chain-group">
+                  {g.consumers.map(c => `${c.manufacturer} ${c.model}`).join(' + ')} (combined {formatMa(g.combined_ma)} on {g.voltage})
+                </div>
+              ))}
+              <div className="power-budget__daisy-chain-disclaimer">
+                This is only a suggestion — noise issues may still occur from sharing power outputs or using non-isolated power.
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    } else if (outputDiff > 0) {
+      warnings.push(
+        <div key="output-count" className="power-budget__warning power-budget__warning--info">
+          {outputDiff} unused output{outputDiff !== 1 ? 's' : ''} available for future expansion.
+        </div>
+      );
+    }
+
+    // 2. Isolation warning
+    const totalIsolated = supplies.reduce((sum, s) => sum + (s.isolated_output_count ?? 0), 0);
+    const nonIsolatedCount = totalOutputCount - totalIsolated;
+    if (nonIsolatedCount > 0) {
+      const supplyLabel = supplies.length === 1
+        ? `Your ${supplies[0].manufacturer} ${supplies[0].model} has`
+        : 'Your power supplies have';
+      warnings.push(
+        <div key="isolation" className="power-budget__warning power-budget__warning--info">
+          <strong>Isolation:</strong> {supplyLabel} {nonIsolatedCount} non-isolated output{nonIsolatedCount !== 1 ? 's' : ''}. Non-isolated outputs can introduce noise — particularly with digital pedals, though analog pedals may also be affected.
+        </div>
+      );
+    }
+
+    // 3. Polarity mismatch
+    const majorityPolarity = getMajorityPolarity(allOutputJacks);
+    if (majorityPolarity) {
+      const mismatched = consumers.filter(c => c.polarity != null && c.polarity !== majorityPolarity);
+      for (const c of mismatched) {
+        warnings.push(
+          <div key={`polarity-${c.manufacturer}-${c.model}`} className="power-budget__warning power-budget__warning--warn">
+            <strong>Polarity:</strong> {c.manufacturer} {c.model} requires {c.polarity} — you may need a polarity-reversal adapter cable.
+          </div>
+        );
+      }
+    }
+
+    // 4. Connector type mismatch
+    const majorityConnector = getMajorityConnector(allOutputJacks);
+    if (majorityConnector) {
+      const mismatched = consumers.filter(c => c.connector_type != null && c.connector_type !== majorityConnector);
+      for (const c of mismatched) {
+        warnings.push(
+          <div key={`connector-${c.manufacturer}-${c.model}`} className="power-budget__warning power-budget__warning--warn">
+            <strong>Connector:</strong> {c.manufacturer} {c.model} uses a {c.connector_type} connector — you may need an adapter cable.
+          </div>
+        );
+      }
+    }
+
+    // 5. Mounting info
+    const mountingTypes = supplies
+      .map(s => s.mounting_type)
+      .filter((m): m is string => m != null);
+    if (mountingTypes.length > 0) {
+      const unique = Array.from(new Set(mountingTypes));
+      warnings.push(
+        <div key="mounting" className="power-budget__warning power-budget__warning--neutral">
+          <strong>Mounting:</strong> {unique.join(', ')}
+        </div>
+      );
+    }
+  }
 
   return (
     <div className="power-budget">
@@ -119,10 +344,7 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
       {status === 'no-supply' && (
         <div className="power-budget__prompt">
           <p>No power supply in workbench.</p>
-          <Link
-            to={totalDraw > 0 ? `/power-supplies?minCurrent=${totalDraw}` : '/power-supplies'}
-            className="power-budget__link"
-          >
+          <Link to={supplyLinkUrl} className="power-budget__link">
             See all compatible power supplies {'\u2192'}
           </Link>
         </div>
@@ -150,10 +372,7 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
               ))}
             </div>
           )}
-          <Link
-            to={`/power-supplies?minCurrent=${totalDraw}`}
-            className="power-budget__link"
-          >
+          <Link to={supplyLinkUrl} className="power-budget__link">
             Find additional power supplies {'\u2192'}
           </Link>
         </>
@@ -188,6 +407,13 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
             </>
           )}
         </>
+      )}
+
+      {/* Warnings */}
+      {warnings.length > 0 && (
+        <div className="power-budget__warnings">
+          {warnings}
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/Workbench/index.scss
+++ b/apps/web/src/components/Workbench/index.scss
@@ -600,4 +600,69 @@
     color: #888;
     padding: 2px 0;
   }
+
+  &__warnings {
+    margin-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  &__warning {
+    font-size: 11px;
+    line-height: 1.5;
+    padding: 6px 8px;
+    border-radius: 4px;
+    border-left: 3px solid transparent;
+
+    strong {
+      color: #c8c8c8;
+    }
+
+    &--warn {
+      color: #d4a55a;
+      border-left-color: #d4a55a;
+      background: #1e1a14;
+    }
+
+    &--info {
+      color: #999;
+      border-left-color: #555;
+      background: #161616;
+    }
+
+    &--neutral {
+      color: #888;
+      border-left-color: #333;
+      background: #141414;
+    }
+  }
+
+  &__daisy-chain {
+    margin-top: 6px;
+    padding-left: 8px;
+    border-left: 2px solid #3a3020;
+  }
+
+  &__daisy-chain-title {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    color: #999;
+    margin-bottom: 4px;
+  }
+
+  &__daisy-chain-group {
+    font-size: 11px;
+    color: #b0a080;
+    padding: 2px 0;
+  }
+
+  &__daisy-chain-disclaimer {
+    font-size: 10px;
+    color: #777;
+    font-style: italic;
+    margin-top: 4px;
+  }
 }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -243,11 +243,20 @@ paths:
         Returns all power supplies with full details and jacks. Filtering is performed
         client-side by the frontend.
 
-        The frontend Power Supplies view (`/power-supplies`) accepts a `minCurrent` URL
-        search param (e.g., `/power-supplies?minCurrent=2780`) to pre-filter the display
-        by minimum total current capacity in milliamps. This is a frontend-only param used
-        for cross-view deep linking (e.g., from the workbench power budget insight) and is
-        not passed to this API endpoint. See ADR #6 for details.
+        The frontend Power Supplies view (`/power-supplies`) accepts several URL search
+        params for cross-view deep linking (e.g., from the workbench Power Budget insight).
+        These are **frontend-only params** — they are not passed to this API endpoint.
+
+        | Param | Type | Example | Meaning |
+        |-------|------|---------|---------|
+        | `minCurrent` | integer | `2780` | Minimum total current capacity (mA) |
+        | `minOutputs` | integer | `8` | Minimum number of power outputs |
+        | `minOutputCurrent` | integer | `300` | At least one output jack must provide this many mA |
+        | `voltages` | comma-separated | `9V,18V` | Supply must offer all listed voltages |
+
+        When any of these params are present, the view filters the dataset client-side,
+        displays a context banner summarizing the active filters, and sorts by total
+        current capacity descending. A "Clear" button removes all URL-param filters at once.
       responses:
         '200':
           description: List of power supplies with full details and jacks
@@ -974,7 +983,16 @@ components:
     # ──────────────────────────────────────────
     PowerSupply:
       type: object
-      description: Full power supply DTO with product info, power supply details, and jacks.
+      description: |
+        Full power supply DTO with product info, power supply details, and jacks.
+
+        Key fields used by the frontend Power Budget insight for compatibility warnings:
+        - `totalOutputCount` / `isolatedOutputCount` — output count vs. pedal count, isolation warnings
+        - `supplyType` — isolation classification (Isolated, Non-Isolated, Hybrid)
+        - `availableVoltages` — voltage compatibility checking
+        - `mountingType` — informational display
+        - `jacks[].voltage`, `jacks[].currentMa`, `jacks[].polarity`, `jacks[].connectorType` —
+          per-output matching for polarity/connector mismatch warnings and daisy-chain grouping
       properties:
         id:
           type: integer

--- a/docs/plans/power-budget-tool-plan.md
+++ b/docs/plans/power-budget-tool-plan.md
@@ -134,5 +134,6 @@ Pedals with unknown power requirements are excluded from grouping and flagged se
 1. **Build check**: `cd apps/web && npm run build` — no compile errors
 2. **Tests**: `cd apps/web && npm test` — existing tests pass (update PowerBudgetInsight tests if any exist)
 3. **Manual test — URL params**: Navigate to `/power-supplies?minCurrent=2000&minOutputs=6&minOutputCurrent=300&voltages=9V,18V` and verify filtering works and banner displays correctly
-4. **Manual test — insight warnings**: Add a mix of pedals (some 9V, one 18V, one center-positive) and a power supply to the workbench. Verify warnings appear for voltage, polarity, connector mismatches, and isolation
-5. **Manual test — link generation**: With pedals in the workbench but no supply, click "See all compatible power supplies" and verify the URL contains all relevant params
+4. **Manual test — insight warnings**: Add a mix of pedals (some 9V, one 18V, one center-positive) and a power supply to the workbench. Verify warnings appear for output count, voltage, polarity, connector mismatches, isolation, and mounting
+5. **Manual test — daisy-chain suggestion**: Add more pedals than the supply has outputs. Verify the grouping suggestion appears with compatible pedals identified and the noise disclaimer is shown
+6. **Manual test — link generation**: With pedals in the workbench but no supply, click "See all compatible power supplies" and verify the URL contains `minCurrent`, `minOutputs`, `minOutputCurrent`, and `voltages` params


### PR DESCRIPTION
Enhances the workbench Power Budget insight from a single-dimension current check to a multi-dimension compatibility tool, and adds smart filtering to the Power Supplies catalog view.

  Changes

  Power Budget Insight (PowerBudgetInsight.tsx)

  - Expanded PowerConsumer interface to extract voltage, polarity, and connector type from power input jacks
  - Expanded PowerSupplyInfo interface to read output count, isolation count, supply type, available voltages, mounting type, and power output jacks
  - Smart link generation: "See all compatible power supplies" link now includes minCurrent, minOutputs, minOutputCurrent, and voltages params computed from the workbench contents
  - 5 new informational warnings (only shown when a supply is present):
    a. Output count — warns when fewer outputs than pedals, with daisy-chain grouping suggestions for electrically compatible pedals (same voltage/polarity/connector, combined draw fits within an output
  capacity). Includes noise disclaimer. Notes unused outputs when supply has more than needed.
    b. Isolation — flags non-isolated outputs with a note about potential noise
    c. Polarity mismatch — identifies pedals requiring different polarity than the supply's majority
    d. Connector type mismatch — identifies pedals using a different connector than the supply's majority
    e. Mounting info — simple informational line showing the supply's mounting type

  Power Supplies View (PowerSupplies/index.tsx)

  - 3 new URL param filters (all client-side, no API changes):
    - minOutputs — minimum number of power outputs
    - minOutputCurrent — at least one output jack must provide this many mA
    - voltages — comma-separated list; supply must offer all listed voltages
  - minCurrent (existing) now actually filters out supplies below the threshold instead of only adjusting sort order
  - Updated context banner — shows all active filters in a single line (e.g., "Showing power supplies with 2,780mA+ capacity, 8+ outputs, 300mA+ per output, 9V + 18V")
  - Clear button removes all URL-param filters at once

  Styles (Workbench/index.scss)

  - Added styles for __warnings, __warning (with --warn, --info, --neutral variants), and __daisy-chain sub-elements

  Documentation (docs/openapi.yaml)

  - Updated /api/power-supplies endpoint description with a table documenting all four frontend URL params
  - Updated PowerSupply schema description listing fields used by the Power Budget insight for compatibility warnings

  Notes

  - No API changes — all new logic is client-side using data already returned by existing endpoints
  - No new dependencies
  - All existing tests pass, build compiles cleanly