### PR TITLE
Add product_sources table for per-field data provenance

### DIFF
--- a/apps/api/src/main/java/com/pedalshootout/api/entity/Product.java
+++ b/apps/api/src/main/java/com/pedalshootout/api/entity/Product.java
@@ -1,6 +1,7 @@
 package com.pedalshootout.api.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
 /**
@@ -77,6 +78,9 @@ public class Product {
 
     private String notes;
 
+    @Column(name = "last_researched_at")
+    private LocalDate lastResearchedAt;
+
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
 
@@ -104,6 +108,7 @@ public class Product {
     public String getTags() { return tags; }
     public String getDataReliability() { return dataReliability; }
     public String getNotes() { return notes; }
+    public LocalDate getLastResearchedAt() { return lastResearchedAt; }
     public OffsetDateTime getCreatedAt() { return createdAt; }
     public OffsetDateTime getUpdatedAt() { return updatedAt; }
 }

--- a/apps/api/src/main/java/com/pedalshootout/api/entity/ProductSource.java
+++ b/apps/api/src/main/java/com/pedalshootout/api/entity/ProductSource.java
@@ -1,0 +1,75 @@
+package com.pedalshootout.api.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * JPA Entity for the product_sources table.
+ *
+ * Tracks data provenance — where each field value came from, what the source
+ * reported, and how reliable that source is. This enables per-field reliability
+ * auditing and discrepancy detection when multiple sources report different values.
+ *
+ * @ManyToOne on product means "many source entries belong to one product."
+ * @ManyToOne on jack is nullable — only populated when table_name = 'jacks',
+ * identifying which specific jack the source covers.
+ */
+@Entity
+@Table(name = "product_sources")
+public class ProductSource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "jack_id")
+    private Jack jack;
+
+    @Column(name = "table_name", nullable = false)
+    private String tableName;
+
+    @Column(name = "field_name", nullable = false)
+    private String fieldName;
+
+    @Column(name = "value_recorded")
+    private String valueRecorded;
+
+    @Column(name = "source_url")
+    private String sourceUrl;
+
+    @Column(name = "source_type", nullable = false)
+    private String sourceType;
+
+    @Column(nullable = false)
+    private String reliability;
+
+    @Column(name = "accessed_at", nullable = false)
+    private LocalDate accessedAt;
+
+    private String notes;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    public ProductSource() {}
+
+    // --- Getters ---
+    public Integer getId() { return id; }
+    public Product getProduct() { return product; }
+    public Jack getJack() { return jack; }
+    public String getTableName() { return tableName; }
+    public String getFieldName() { return fieldName; }
+    public String getValueRecorded() { return valueRecorded; }
+    public String getSourceUrl() { return sourceUrl; }
+    public String getSourceType() { return sourceType; }
+    public String getReliability() { return reliability; }
+    public LocalDate getAccessedAt() { return accessedAt; }
+    public String getNotes() { return notes; }
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+}

--- a/apps/api/src/main/resources/db/migration/V3__create_product_sources.sql
+++ b/apps/api/src/main/resources/db/migration/V3__create_product_sources.sql
@@ -1,0 +1,37 @@
+-- Add data provenance tracking: product_sources table and last_researched_at column
+
+-- Convenience column for quickly identifying stale records
+ALTER TABLE products ADD COLUMN last_researched_at DATE;
+
+-- Per-field, per-source provenance tracking
+CREATE TABLE product_sources (
+    id              INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    product_id      INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    jack_id         INTEGER REFERENCES jacks(id) ON DELETE CASCADE,
+    table_name      TEXT NOT NULL CHECK (table_name IN (
+        'products', 'pedal_details', 'power_supply_details',
+        'pedalboard_details', 'midi_controller_details',
+        'utility_details', 'plug_details', 'jacks'
+    )),
+    field_name      TEXT NOT NULL,
+    value_recorded  TEXT,
+    source_url      TEXT,
+    source_type     TEXT NOT NULL CHECK (source_type IN (
+        'manufacturer_website', 'manufacturer_manual', 'manufacturer_direct',
+        'major_retailer', 'community_database', 'review_site',
+        'user_submission', 'other'
+    )),
+    reliability     TEXT NOT NULL CHECK (reliability IN ('High', 'Medium', 'Low')),
+    accessed_at     DATE NOT NULL DEFAULT CURRENT_DATE,
+    notes           TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (
+        (table_name = 'jacks' AND jack_id IS NOT NULL)
+        OR (table_name != 'jacks' AND jack_id IS NULL)
+    )
+);
+
+CREATE INDEX idx_product_sources_product ON product_sources(product_id);
+CREATE INDEX idx_product_sources_field ON product_sources(field_name);
+CREATE INDEX idx_product_sources_reliability ON product_sources(reliability);

--- a/data/schema/gear_postgres.sql
+++ b/data/schema/gear_postgres.sql
@@ -61,6 +61,7 @@ CREATE TABLE products (
     tags TEXT,                            -- Comma-separated: 'transparent', 'amp-in-a-box', 'tour-grade', etc.
     data_reliability TEXT CHECK(data_reliability IN ('High', 'Medium', 'Low')),  -- Confidence in data accuracy
     notes TEXT,                           -- Internal notes for data quality/sourcing
+    last_researched_at DATE,              -- When specs were last researched/verified
     created_at TIMESTAMPTZ DEFAULT NOW(), -- Row creation timestamp
     updated_at TIMESTAMPTZ DEFAULT NOW(), -- Last modification timestamp
 
@@ -373,6 +374,44 @@ CREATE TABLE plug_details (
 
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
 );
+
+-- =============================================================================
+-- DATA PROVENANCE
+-- =============================================================================
+
+-- Tracks where each data point came from, enabling per-field reliability auditing
+-- and discrepancy detection when multiple sources report different values.
+CREATE TABLE product_sources (
+    id              INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    product_id      INTEGER NOT NULL REFERENCES products(id) ON DELETE CASCADE,
+    jack_id         INTEGER REFERENCES jacks(id) ON DELETE CASCADE,
+    table_name      TEXT NOT NULL CHECK (table_name IN (
+        'products', 'pedal_details', 'power_supply_details',
+        'pedalboard_details', 'midi_controller_details',
+        'utility_details', 'plug_details', 'jacks'
+    )),
+    field_name      TEXT NOT NULL,
+    value_recorded  TEXT,
+    source_url      TEXT,
+    source_type     TEXT NOT NULL CHECK (source_type IN (
+        'manufacturer_website', 'manufacturer_manual', 'manufacturer_direct',
+        'major_retailer', 'community_database', 'review_site',
+        'user_submission', 'other'
+    )),
+    reliability     TEXT NOT NULL CHECK (reliability IN ('High', 'Medium', 'Low')),
+    accessed_at     DATE NOT NULL DEFAULT CURRENT_DATE,
+    notes           TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CHECK (
+        (table_name = 'jacks' AND jack_id IS NOT NULL)
+        OR (table_name != 'jacks' AND jack_id IS NULL)
+    )
+);
+
+CREATE INDEX idx_product_sources_product ON product_sources(product_id);
+CREATE INDEX idx_product_sources_field ON product_sources(field_name);
+CREATE INDEX idx_product_sources_reliability ON product_sources(reliability);
 
 -- =============================================================================
 -- COMPATIBILITY TABLE


### PR DESCRIPTION
## Summary

- Adds `product_sources` table to track where each data point came from, what value the source reported, and how reliable it is — enabling per-field reliability auditing and discrepancy detection across sources
- Adds `last_researched_at DATE` column to `products` for quickly identifying stale records without querying `product_sources`
- Flyway migration V3 applied and verified (Hibernate validation passed, CHECK constraints confirmed working)

## Changes

- `data/schema/gear_postgres.sql` — `product_sources` table + `last_researched_at` on products
- `V3__create_product_sources.sql` — Flyway migration
- `ProductSource.java` — JPA entity with `@ManyToOne` to `Product` and nullable `Jack`
- `Product.java` — `lastResearchedAt` field added
- `CLAUDE.md` — `product_sources` in schema overview, required fields table, and new "Recording Data Provenance" section with field conventions and `source_type` reference

## Test plan

- [x] `./mvnw compile -q` passes with no errors
- [x] Flyway applied V3 cleanly on startup (schema at v3)
- [x] Hibernate schema validation passed
- [x] CHECK constraint: `table_name='jacks'` + `jack_id=NULL` → rejected
- [x] CHECK constraint: `table_name='pedal_details'` + non-NULL `jack_id` → rejected
- [x] Valid insert succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)