### PR TITLE
Implement sticky nav, filters, and table headers

### DIFF
--- a/apps/web/src/__tests__/__snapshots__/app.test.tsx.snap
+++ b/apps/web/src/__tests__/__snapshots__/app.test.tsx.snap
@@ -63,198 +63,202 @@ exports[`renders app component 1`] = `
       </div>
     </nav>
     <div
-      class="data-table"
+      class="app__content"
     >
       <div
-        class="data-table__header"
+        class="data-table"
       >
         <div
-          class="data-table__title-group"
+          class="data-table__header"
         >
-          <h1
-            class="data-table__title"
+          <div
+            class="data-table__title-group"
           >
-            Manufacturer Database
-          </h1>
+            <h1
+              class="data-table__title"
+            >
+              Manufacturer Database
+            </h1>
+            <span
+              class="data-table__stats"
+            >
+              0 manufacturers · 0 active · 0 products catalogued
+            </span>
+          </div>
+        </div>
+        <div
+          class="data-table__filters"
+        >
+          <div
+            class="data-table__search-wrapper"
+          >
+            <span
+              class="data-table__search-icon"
+            >
+              ⌕
+            </span>
+            <input
+              class="data-table__search"
+              placeholder="Search manufacturer..."
+              type="text"
+              value=""
+            />
+          </div>
+          <select
+            class="data-table__select"
+          >
+            <option
+              value="All"
+            >
+              Country: All
+            </option>
+          </select>
+          <select
+            class="data-table__select"
+          >
+            <option
+              value="All"
+            >
+              Status: All
+            </option>
+            <option
+              value="Active"
+            >
+              Active
+            </option>
+            <option
+              value="Defunct"
+            >
+              Defunct
+            </option>
+            <option
+              value="Discontinued"
+            >
+              Discontinued
+            </option>
+            <option
+              value="Unknown"
+            >
+              Unknown
+            </option>
+          </select>
           <span
-            class="data-table__stats"
+            class="data-table__filter-count"
           >
-            0 manufacturers · 0 active · 0 products catalogued
+            0
+             
+            manufacturers
+             shown
           </span>
         </div>
-      </div>
-      <div
-        class="data-table__filters"
-      >
         <div
-          class="data-table__search-wrapper"
+          class="data-table__table-wrapper"
         >
-          <span
-            class="data-table__search-icon"
+          <table
+            class="data-table__table"
+            style="min-width: 1050px;"
           >
-            ⌕
-          </span>
-          <input
-            class="data-table__search"
-            placeholder="Search manufacturer..."
-            type="text"
-            value=""
-          />
-        </div>
-        <select
-          class="data-table__select"
-        >
-          <option
-            value="All"
+            <thead>
+              <tr>
+                <th
+                  class="data-table__th"
+                  style="width: 40px; text-align: center; cursor: pointer;"
+                >
+                  #
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 200px; text-align: left; cursor: pointer;"
+                >
+                  Manufacturer
+                  <span
+                    class="data-table__sort-icon active"
+                  >
+                    ▲
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 120px; text-align: left; cursor: pointer;"
+                >
+                  Country
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 80px; text-align: center; cursor: pointer;"
+                >
+                  Founded
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 100px; text-align: center; cursor: pointer;"
+                >
+                  Status
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 280px; text-align: left; cursor: pointer;"
+                >
+                  Specialty
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 64px; text-align: center; cursor: pointer;"
+                >
+                  Products
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+                <th
+                  class="data-table__th"
+                  style="width: 160px; text-align: left; cursor: pointer;"
+                >
+                  Website
+                  <span
+                    class="data-table__sort-icon "
+                  >
+                    ⇅
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody />
+          </table>
+          <div
+            class="data-table__empty"
           >
-            Country: All
-          </option>
-        </select>
-        <select
-          class="data-table__select"
-        >
-          <option
-            value="All"
-          >
-            Status: All
-          </option>
-          <option
-            value="Active"
-          >
-            Active
-          </option>
-          <option
-            value="Defunct"
-          >
-            Defunct
-          </option>
-          <option
-            value="Discontinued"
-          >
-            Discontinued
-          </option>
-          <option
-            value="Unknown"
-          >
-            Unknown
-          </option>
-        </select>
-        <span
-          class="data-table__filter-count"
-        >
-          0
-           
-          manufacturers
-           shown
-        </span>
-      </div>
-      <div
-        class="data-table__table-wrapper"
-      >
-        <table
-          class="data-table__table"
-          style="min-width: 1050px;"
-        >
-          <thead>
-            <tr>
-              <th
-                class="data-table__th"
-                style="width: 40px; text-align: center; cursor: pointer;"
-              >
-                #
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 200px; text-align: left; cursor: pointer;"
-              >
-                Manufacturer
-                <span
-                  class="data-table__sort-icon active"
-                >
-                  ▲
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 120px; text-align: left; cursor: pointer;"
-              >
-                Country
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 80px; text-align: center; cursor: pointer;"
-              >
-                Founded
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 100px; text-align: center; cursor: pointer;"
-              >
-                Status
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 280px; text-align: left; cursor: pointer;"
-              >
-                Specialty
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 64px; text-align: center; cursor: pointer;"
-              >
-                Products
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-              <th
-                class="data-table__th"
-                style="width: 160px; text-align: left; cursor: pointer;"
-              >
-                Website
-                <span
-                  class="data-table__sort-icon "
-                >
-                  ⇅
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody />
-        </table>
-        <div
-          class="data-table__empty"
-        >
-          No 
-          manufacturers
-           match your filters.
+            No 
+            manufacturers
+             match your filters.
+          </div>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/App/app.scss
+++ b/apps/web/src/components/App/app.scss
@@ -2,5 +2,16 @@
 /* See: https://github.com/facebook/create-react-app/blob/main/packages/cra-template-typescript/template/src/App.css */
 
 .app {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	overflow: hidden;
+}
+
+.app__content {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
 	overflow: hidden;
 }

--- a/apps/web/src/components/App/index.tsx
+++ b/apps/web/src/components/App/index.tsx
@@ -30,14 +30,16 @@ const App = () => {
 						key='navElements'
 						elements={navElements}
 					/>
-					<Routes>
-						<Route path='/' element={<Navigate to={navElements[0].link} replace />} />
-						{navElements.map((navElement) => {
-							return <Route key={navElement.link} path={'/' + navElement.link} element={navElement.component}/>
-						})}
-						<Route path='/workbench' element={<Workbench />} />
-						<Route path='*' element={<NotFound />} />
-					</Routes>
+					<div className="app__content">
+						<Routes>
+							<Route path='/' element={<Navigate to={navElements[0].link} replace />} />
+							{navElements.map((navElement) => {
+								return <Route key={navElement.link} path={'/' + navElement.link} element={navElement.component}/>
+							})}
+							<Route path='/workbench' element={<Workbench />} />
+							<Route path='*' element={<NotFound />} />
+						</Routes>
+					</div>
 				</div>
 			</WorkbenchProvider>
 		</Router>

--- a/apps/web/src/components/DataTable/index.scss
+++ b/apps/web/src/components/DataTable/index.scss
@@ -2,8 +2,12 @@
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
   background: #111;
   color: #c8c8c8;
-  min-height: 100vh;
-  padding: 24px 20px 40px;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+  padding: 0 20px;
 
   &__header {
     display: flex;
@@ -12,6 +16,8 @@
     margin-bottom: 18px;
     flex-wrap: wrap;
     gap: 8px;
+    flex-shrink: 0;
+    padding-top: 20px;
   }
 
   &__title-group {
@@ -42,6 +48,7 @@
     flex-wrap: wrap;
     margin-bottom: 16px;
     align-items: center;
+    flex-shrink: 0;
   }
 
   &__search-wrapper {
@@ -105,10 +112,12 @@
   }
 
   &__table-wrapper {
-    overflow-x: auto;
+    overflow: auto;
     border-radius: 6px;
     border: 1px solid #222;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+    flex: 1;
+    min-height: 0;
   }
 
   &__table {
@@ -244,6 +253,7 @@
     color: #8ab8dd;
     font-size: 12px;
     font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    flex-shrink: 0;
   }
 
   &__context-banner-clear {

--- a/apps/web/src/components/Nav/index.scss
+++ b/apps/web/src/components/Nav/index.scss
@@ -8,6 +8,7 @@
 	justify-content: space-between;
 	padding: 0 20px;
 	font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+	flex-shrink: 0;
 
 	&__links {
 		display: flex;

--- a/apps/web/src/components/NotFound/index.scss
+++ b/apps/web/src/components/NotFound/index.scss
@@ -1,3 +1,4 @@
 .not-found {
 	padding: 20px;
+	flex: 1;
 }

--- a/apps/web/src/components/Workbench/index.scss
+++ b/apps/web/src/components/Workbench/index.scss
@@ -2,7 +2,9 @@
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
   background: #111;
   color: #c8c8c8;
-  min-height: 100vh;
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
   padding: 24px 20px 40px;
 
   &__header {
@@ -306,7 +308,7 @@
   background: #161616;
   border-left: 1px solid #2a2a2a;
   overflow-y: auto;
-  max-height: calc(100vh - 160px);
+  max-height: calc(100% - 40px);
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
 
   &__header {

--- a/apps/web/src/components/Workbench/index.scss
+++ b/apps/web/src/components/Workbench/index.scss
@@ -3,11 +3,15 @@
   background: #111;
   color: #c8c8c8;
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;
   min-height: 0;
-  padding: 24px 20px 40px;
+  display: flex;
+  flex-direction: column;
+  padding: 0 20px;
 
   &__header {
+    flex-shrink: 0;
+    padding-top: 24px;
     margin-bottom: 24px;
   }
 
@@ -128,12 +132,16 @@
     display: flex;
     gap: 0;
     position: relative;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
   }
 
   &__content {
-    overflow-x: auto;
+    overflow: auto;
     flex: 1;
     min-width: 0;
+    min-height: 0;
   }
 
   &__table-wrapper {
@@ -158,6 +166,10 @@
     border-bottom: 1px solid #2a2a2a;
     white-space: nowrap;
     user-select: none;
+    position: sticky;
+    top: 0;
+    background: #111;
+    z-index: 2;
   }
 
   &__row {
@@ -308,7 +320,6 @@
   background: #161616;
   border-left: 1px solid #2a2a2a;
   overflow-y: auto;
-  max-height: calc(100% - 40px);
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
 
   &__header {
@@ -443,6 +454,7 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow-y: auto;
   font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
 
   &__card {

--- a/apps/web/src/index.scss
+++ b/apps/web/src/index.scss
@@ -1,11 +1,16 @@
 @import './styles/badges';
 
+html, body {
+	height: 100%;
+}
+
 body {
 	margin: 0;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	background-color: #343842;
+	overflow: hidden;
 }
 
 code {

--- a/docs/plans/todo.md
+++ b/docs/plans/todo.md
@@ -23,7 +23,7 @@
 - [ ] **Signal path validator** - Flag mono/stereo mismatches, impedance issues
 - [ ] **MIDI routing helper** - Match controller outputs to pedal MIDI needs
 - [ ] **Unit toggle** - Enable toggle for units of measurement (mm ↔ inches)
-- [ ] **Sticky nav** - Make top nav sticky
+- [x] **Sticky nav, filters, and table headers** - Viewport-locked flex layout keeps nav, filters, and column headers fixed while only table body rows scroll
 
 ## 4. Spring Boot API:
 


### PR DESCRIPTION
## Summary
- Convert the app to a viewport-locked flex layout so the navbar, filter controls, and table column headers remain fixed while only table body rows scroll
- Wrap `<Routes>` in a new `.app__content` flex container that fills remaining viewport height below the nav
- Update DataTable, Workbench, and NotFound components to participate in the flex layout

## Test plan
- [x] `npm run web:build` — no build errors
- [x] `npm run web:test` — all tests pass (snapshot updated)
- [x] Manual: verify sticky nav/filters/headers on Pedals view with long table
- [x] Manual: verify expanded rows scroll correctly within the table body
- [x] Manual: verify Workbench fills viewport and detail panel scrolls properly
- [x] Manual: verify horizontal scroll still works on narrow viewports
- [x] Manual: verify Power Supplies context banner stays visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)