### PR TITLE
Add canvas-based Layout and Power views to Workbench

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,8 @@ cd apps/api
 - Managed via nvm (installed at `~/.nvm`); project is pinned to Node 20 via `.nvmrc`
 - nvm is NOT auto-loaded in non-interactive shells (such as the shell Claude Code uses)
 - All `node`/`npm` commands must be prefixed with: `export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" &&`
-- Example: `export NVM_DIR="$HOME/.nvm" && . "$NVM_DIR/nvm.sh" && npm run web --prefix /path/to/project`
+- If using zsh, the `.` (source) command can fail with ambiguous syntax errors. Use `\. "$NVM_DIR/nvm.sh"` (backslash-escaped dot) instead: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" &&`
+- Example: `export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && npm run web --prefix /path/to/project`
 
 ## Web App Architecture
 

--- a/apps/web/jest.config.js
+++ b/apps/web/jest.config.js
@@ -6,6 +6,9 @@ module.exports = {
 		'\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
 			'<rootDir>/src/__mocks__/fileMock.ts',
 		'\\.(css|less|scss|sass)$': '<rootDir>/src/__mocks__/styleMock.ts',
+		'^konva$': '<rootDir>/src/__mocks__/konvaMock.ts',
+		'^konva/(.*)$': '<rootDir>/src/__mocks__/konvaMock.ts',
+		'^react-konva$': '<rootDir>/src/__mocks__/reactKonvaMock.ts',
 	},
 	setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
 	collectCoverageFrom: ['**/*.{ts,tsx}', '!**/*.d.ts', '!**/node_modules/**', '!**/vendor/**'],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,10 +48,12 @@
 	},
 	"dependencies": {
 		"@rjsf/core": "^4.2.0",
+		"konva": "^10.2.0",
 		"node-polyfill-webpack-plugin": "^2.0.0",
 		"react": "^18.2.0",
 		"react-classlist": "^1.1.2",
 		"react-dom": "^18.2.0",
+		"react-konva": "^18.2.14",
 		"react-router-dom": "^6.3.0"
 	}
 }

--- a/apps/web/src/__mocks__/konvaMock.ts
+++ b/apps/web/src/__mocks__/konvaMock.ts
@@ -1,0 +1,6 @@
+const Konva = {
+  KonvaEventObject: {},
+};
+
+export default Konva;
+export { Konva };

--- a/apps/web/src/__mocks__/reactKonvaMock.ts
+++ b/apps/web/src/__mocks__/reactKonvaMock.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const createMockComponent = (name: string) => {
+  return React.forwardRef((props: any, ref: any) => {
+    const { children, ...rest } = props;
+    return React.createElement(name, { ...rest, ref }, children);
+  });
+};
+
+export const Stage = createMockComponent('Stage');
+export const Layer = createMockComponent('Layer');
+export const Rect = createMockComponent('Rect');
+export const Text = createMockComponent('Text');
+export const Group = createMockComponent('Group');
+export const Line = createMockComponent('Line');
+export const Arrow = createMockComponent('Arrow');
+export const Circle = createMockComponent('Circle');

--- a/apps/web/src/__tests__/utils/powerUtils.test.ts
+++ b/apps/web/src/__tests__/utils/powerUtils.test.ts
@@ -1,0 +1,110 @@
+import {
+  normalizePolarity,
+  normalizeConnector,
+  normalizeVoltage,
+  voltageTokensFromJack,
+  voltageTokensCanSatisfy,
+  voltagesCompatible,
+  validateConnection,
+} from '../../utils/powerUtils';
+
+describe('normalizePolarity', () => {
+  it('lowercases and replaces spaces with hyphens', () => {
+    expect(normalizePolarity('Center Negative')).toBe('center-negative');
+    expect(normalizePolarity('Center Positive')).toBe('center-positive');
+  });
+});
+
+describe('normalizeConnector', () => {
+  it('trims whitespace', () => {
+    expect(normalizeConnector(' 2.1mm barrel ')).toBe('2.1mm barrel');
+  });
+});
+
+describe('normalizeVoltage', () => {
+  it('strips V, DC, AC', () => {
+    expect(normalizeVoltage('9V DC')).toBe('9');
+    expect(normalizeVoltage('9V/12V/18V')).toBe('9/12/18');
+    expect(normalizeVoltage('100-240V AC')).toBe('100-240');
+  });
+});
+
+describe('voltageTokensFromJack', () => {
+  it('splits by slash', () => {
+    expect(voltageTokensFromJack('9V/12V/18V')).toEqual(['9', '12', '18']);
+  });
+
+  it('handles single voltage', () => {
+    expect(voltageTokensFromJack('9V')).toEqual(['9']);
+  });
+});
+
+describe('voltageTokensCanSatisfy', () => {
+  it('matches exact', () => {
+    expect(voltageTokensCanSatisfy(['9', '12'], '9')).toBe(true);
+  });
+
+  it('rejects missing', () => {
+    expect(voltageTokensCanSatisfy(['12'], '9')).toBe(false);
+  });
+
+  it('matches range', () => {
+    expect(voltageTokensCanSatisfy(['9-18'], '12')).toBe(true);
+    expect(voltageTokensCanSatisfy(['9-18'], '24')).toBe(false);
+  });
+});
+
+describe('voltagesCompatible', () => {
+  it('matches single voltage', () => {
+    expect(voltagesCompatible('9V', '9V')).toBe(true);
+    expect(voltagesCompatible('12V', '9V')).toBe(false);
+  });
+
+  it('selectable supply matches consumer', () => {
+    expect(voltagesCompatible('9V/12V/18V', '9V')).toBe(true);
+    expect(voltagesCompatible('9V/12V/18V', '24V')).toBe(false);
+  });
+});
+
+describe('validateConnection', () => {
+  const baseOutput = { voltage: '9V', current_ma: 500, polarity: 'Center Negative', connector_type: '2.1mm barrel' };
+  const baseInput = { voltage: '9V', current_ma: 100, polarity: 'Center Negative', connector_type: '2.1mm barrel' };
+
+  it('returns valid for matching jacks', () => {
+    const result = validateConnection(baseOutput, baseInput);
+    expect(result.status).toBe('valid');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('returns error for voltage mismatch', () => {
+    const result = validateConnection(baseOutput, { ...baseInput, voltage: '18V' });
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toMatch(/Voltage mismatch/);
+  });
+
+  it('returns error for current overload', () => {
+    const result = validateConnection(baseOutput, baseInput, 600);
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toMatch(/Current overload/);
+  });
+
+  it('returns warning for polarity mismatch', () => {
+    const result = validateConnection(baseOutput, { ...baseInput, polarity: 'Center Positive' });
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0]).toMatch(/Polarity mismatch/);
+  });
+
+  it('returns warning for connector mismatch', () => {
+    const result = validateConnection(baseOutput, { ...baseInput, connector_type: '2.5mm barrel' });
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0]).toMatch(/Connector mismatch/);
+  });
+
+  it('handles null values gracefully', () => {
+    const result = validateConnection(
+      { voltage: null, current_ma: null, polarity: null, connector_type: null },
+      { voltage: null, current_ma: null, polarity: null, connector_type: null },
+    );
+    expect(result.status).toBe('valid');
+  });
+});

--- a/apps/web/src/components/Workbench/CanvasBase.tsx
+++ b/apps/web/src/components/Workbench/CanvasBase.tsx
@@ -1,0 +1,65 @@
+import { useRef, useState, useEffect, ReactNode } from 'react';
+import { Stage, Layer, Rect } from 'react-konva';
+import Konva from 'konva';
+
+interface CanvasBaseProps {
+  children: ReactNode;
+  onStageClick?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
+  onStageMouseMove?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
+  onStageMouseUp?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
+}
+
+/**
+ * Shared Konva canvas wrapper that auto-sizes to fill its parent container.
+ * Renders a dark background layer and a content layer for children.
+ */
+const CanvasBase = ({ children, onStageClick, onStageMouseMove, onStageMouseUp }: CanvasBaseProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const updateSize = () => {
+      setDimensions({
+        width: container.clientWidth,
+        height: container.clientHeight,
+      });
+    };
+
+    updateSize();
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+      {/* @ts-expect-error react-konva v18 types don't include children prop on Stage */}
+      <Stage
+        width={dimensions.width}
+        height={dimensions.height}
+        onClick={onStageClick}
+        onMouseMove={onStageMouseMove}
+        onMouseUp={onStageMouseUp}
+      >
+        <Layer>
+          <Rect
+            x={0}
+            y={0}
+            width={dimensions.width}
+            height={dimensions.height}
+            fill="#111"
+          />
+        </Layer>
+        <Layer>
+          {children}
+        </Layer>
+      </Stage>
+    </div>
+  );
+};
+
+export default CanvasBase;

--- a/apps/web/src/components/Workbench/ConnectionLine.tsx
+++ b/apps/web/src/components/Workbench/ConnectionLine.tsx
@@ -1,0 +1,59 @@
+import { Line } from 'react-konva';
+
+const STATUS_COLORS = {
+  valid: '#6aaa6a',
+  warning: '#d4a55a',
+  error: '#cc6060',
+};
+
+const ACKNOWLEDGED_COLOR = '#8a7a3a';
+
+interface ConnectionLineProps {
+  sourceX: number;
+  sourceY: number;
+  targetX: number;
+  targetY: number;
+  status: 'valid' | 'warning' | 'error';
+  acknowledged?: boolean;
+  onClick?: () => void;
+  selected?: boolean;
+}
+
+/**
+ * A connection line between two port dots on the Power canvas.
+ * Renders a cubic bezier curve colored by validation status.
+ */
+const ConnectionLine = ({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  status,
+  acknowledged = false,
+  onClick,
+  selected = false,
+}: ConnectionLineProps) => {
+  const color = acknowledged ? ACKNOWLEDGED_COLOR : STATUS_COLORS[status];
+  const strokeWidth = selected ? 3 : 2;
+
+  // Bezier control point offset — curve bows out horizontally
+  const dx = Math.abs(targetX - sourceX) * 0.4;
+
+  return (
+    <Line
+      points={[sourceX, sourceY, sourceX + dx, sourceY, targetX - dx, targetY, targetX, targetY]}
+      stroke={color}
+      strokeWidth={strokeWidth}
+      bezier
+      dash={acknowledged ? [6, 4] : undefined}
+      hitStrokeWidth={12}
+      onClick={onClick}
+      onTap={onClick}
+      shadowColor={selected ? color : undefined}
+      shadowBlur={selected ? 8 : 0}
+      shadowOpacity={selected ? 0.5 : 0}
+    />
+  );
+};
+
+export default ConnectionLine;

--- a/apps/web/src/components/Workbench/LayoutView.tsx
+++ b/apps/web/src/components/Workbench/LayoutView.tsx
@@ -1,0 +1,69 @@
+import { useWorkbench } from '../../context/WorkbenchContext';
+import { WorkbenchRow } from './WorkbenchTable';
+import CanvasBase from './CanvasBase';
+import ProductCard from './ProductCard';
+
+const VIEW_KEY = 'layout';
+const GRID_COLUMNS = 4;
+const CARD_SPACING_X = 160;
+const CARD_SPACING_Y = 84;
+const GRID_OFFSET_X = 20;
+const GRID_OFFSET_Y = 20;
+
+/** Assign a default grid position for products without a saved position */
+function defaultPosition(index: number): { x: number; y: number } {
+  const col = index % GRID_COLUMNS;
+  const row = Math.floor(index / GRID_COLUMNS);
+  return {
+    x: GRID_OFFSET_X + col * CARD_SPACING_X,
+    y: GRID_OFFSET_Y + row * CARD_SPACING_Y,
+  };
+}
+
+interface LayoutViewProps {
+  rows: WorkbenchRow[];
+}
+
+const LayoutView = ({ rows }: LayoutViewProps) => {
+  const { getViewPositions, updateViewPosition } = useWorkbench();
+  const savedPositions = getViewPositions(VIEW_KEY);
+
+  const getPosition = (productId: number, index: number) => {
+    const saved = savedPositions[String(productId)];
+    if (saved) return saved;
+    return defaultPosition(index);
+  };
+
+  const handleDragEnd = (productId: number, x: number, y: number) => {
+    updateViewPosition(VIEW_KEY, productId, x, y);
+  };
+
+  if (rows.length === 0) {
+    return (
+      <div className="workbench__canvas-placeholder">
+        Your workbench is empty. Add products from the catalog views.
+      </div>
+    );
+  }
+
+  return (
+    <CanvasBase>
+      {rows.map((row, index) => {
+        const pos = getPosition(row.id, index);
+        return (
+          <ProductCard
+            key={row.id}
+            productType={row.product_type}
+            manufacturer={row.manufacturer}
+            model={row.model}
+            x={pos.x}
+            y={pos.y}
+            onDragEnd={(x, y) => handleDragEnd(row.id, x, y)}
+          />
+        );
+      })}
+    </CanvasBase>
+  );
+};
+
+export default LayoutView;

--- a/apps/web/src/components/Workbench/PortDot.tsx
+++ b/apps/web/src/components/Workbench/PortDot.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { Circle, Text, Group } from 'react-konva';
+import Konva from 'konva';
+
+interface PortDotProps {
+  x: number;
+  y: number;
+  jackId: number;
+  label: string;
+  direction: 'output' | 'input';
+  color?: string;
+  isolated?: boolean;
+  onMouseDown?: (jackId: number, e: Konva.KonvaEventObject<MouseEvent>) => void;
+  onClick?: (jackId: number) => void;
+  onMouseEnter?: (jackId: number) => void;
+  onMouseLeave?: () => void;
+}
+
+const DOT_RADIUS = 6;
+const HOVER_RADIUS = 8;
+
+/**
+ * A small clickable port circle rendered on a ProductCard.
+ * Output dots sit on the right side of supply cards.
+ * Input dots sit on the left side of consumer cards.
+ */
+const PortDot = ({
+  x,
+  y,
+  jackId,
+  label,
+  direction,
+  color = '#6aaa6a',
+  isolated = true,
+  onMouseDown,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+}: PortDotProps) => {
+  const [hovered, setHovered] = useState(false);
+  const radius = hovered ? HOVER_RADIUS : DOT_RADIUS;
+
+  const isOutput = direction === 'output';
+  const labelX = isOutput ? DOT_RADIUS + 6 : -(DOT_RADIUS + 6);
+  const labelAlign = isOutput ? 'left' : 'right';
+
+  return (
+    <Group x={x} y={y}>
+      <Circle
+        radius={radius}
+        fill={isolated ? color : undefined}
+        stroke={color}
+        strokeWidth={isolated ? 1 : 2}
+        onMouseEnter={() => {
+          setHovered(true);
+          onMouseEnter?.(jackId);
+        }}
+        onMouseLeave={() => {
+          setHovered(false);
+          onMouseLeave?.();
+        }}
+        onMouseDown={(e: Konva.KonvaEventObject<MouseEvent>) => {
+          onMouseDown?.(jackId, e);
+        }}
+        onClick={() => onClick?.(jackId)}
+        onTap={() => onClick?.(jackId)}
+      />
+      <Text
+        x={isOutput ? labelX : labelX - 100}
+        y={-5}
+        width={100}
+        text={label}
+        fontSize={9}
+        fontFamily="monospace"
+        fill="#999"
+        align={labelAlign}
+        listening={false}
+      />
+    </Group>
+  );
+};
+
+export default PortDot;

--- a/apps/web/src/components/Workbench/PowerBudgetInsight.tsx
+++ b/apps/web/src/components/Workbench/PowerBudgetInsight.tsx
@@ -1,339 +1,45 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { WorkbenchRow } from './WorkbenchTable';
-import { Jack } from '../../utils/transformers';
-import { normalizePolarity, normalizeConnector, voltagesCompatible } from '../../utils/powerUtils';
+import { normalizePolarity, normalizeConnector } from '../../utils/powerUtils';
+import {
+  extractPowerData,
+  formatMa,
+  getMajorityPolarity,
+  getMajorityConnector,
+  computeDaisyChainGroups,
+  assignPedalsToOutputs,
+  buildSupplyLinkUrl,
+} from '../../utils/powerAssignment';
 
 interface PowerBudgetInsightProps {
   rows: WorkbenchRow[];
 }
 
-interface PowerConsumer {
-  manufacturer: string;
-  model: string;
-  current_ma: number | null;
-  voltage: string | null;
-  polarity: string | null;
-  connector_type: string | null;
-}
-
-interface PowerSupplyInfo {
-  manufacturer: string;
-  model: string;
-  total_current_ma: number | null;
-  total_output_count: number | null;
-  isolated_output_count: number | null;
-  supply_type: string | null;
-  available_voltages: string | null;
-  mounting_type: string | null;
-  output_jacks: Jack[];
-}
-
-function getPowerInputJack(row: WorkbenchRow): Jack | undefined {
-  return row.jacks.find(j => j.category === 'power' && j.direction === 'input');
-}
-
-function getPowerOutputJacks(row: WorkbenchRow): Jack[] {
-  return row.jacks.filter(j => j.category === 'power' && j.direction === 'output');
-}
-
-function formatMa(ma: number): string {
-  return `${ma.toLocaleString()}mA`;
-}
-
-/** Find the majority polarity among supply output jacks (normalized) */
-function getMajorityPolarity(jacks: Jack[]): string | null {
-  const counts: Record<string, number> = {};
-  for (const j of jacks) {
-    if (j.polarity) {
-      const norm = normalizePolarity(j.polarity);
-      counts[norm] = (counts[norm] || 0) + 1;
-    }
-  }
-  let best: string | null = null;
-  let bestCount = 0;
-  for (const [pol, count] of Object.entries(counts)) {
-    if (count > bestCount) {
-      best = pol;
-      bestCount = count;
-    }
-  }
-  return best;
-}
-
-/** Find the majority connector type among supply output jacks (normalized) */
-function getMajorityConnector(jacks: Jack[]): string | null {
-  const counts: Record<string, number> = {};
-  for (const j of jacks) {
-    if (j.connector_type) {
-      const norm = normalizeConnector(j.connector_type);
-      counts[norm] = (counts[norm] || 0) + 1;
-    }
-  }
-  let best: string | null = null;
-  let bestCount = 0;
-  for (const [ct, count] of Object.entries(counts)) {
-    if (count > bestCount) {
-      best = ct;
-      bestCount = count;
-    }
-  }
-  return best;
-}
-
-interface DaisyChainGroup {
-  voltage: string;
-  polarity: string;
-  connector_type: string;
-  consumers: PowerConsumer[];
-  combined_ma: number;
-  max_output_ma: number | null;
-}
-
-/**
- * When the supply has fewer outputs than pedals, identify groups of
- * electrically compatible pedals that could share an output via daisy-chain.
- */
-function computeDaisyChainGroups(
-  consumers: PowerConsumer[],
-  outputJacks: Jack[],
-): DaisyChainGroup[] {
-  // Only consumers with full known power specs can be grouped
-  const eligible = consumers.filter(
-    c => c.current_ma != null && c.voltage != null && c.polarity != null && c.connector_type != null,
-  );
-
-  // Group by (voltage, polarity, connector_type)
-  const groupMap = new Map<string, PowerConsumer[]>();
-  for (const c of eligible) {
-    const key = `${c.voltage}|${c.polarity}|${c.connector_type}`;
-    const arr = groupMap.get(key);
-    if (arr) arr.push(c);
-    else groupMap.set(key, [c]);
-  }
-
-  const groups: DaisyChainGroup[] = [];
-  for (const [key, members] of Array.from(groupMap)) {
-    if (members.length < 2) continue; // need at least 2 to daisy-chain
-    const [voltage, polarity, connector_type] = key.split('|');
-    const combinedMa = members.reduce((sum: number, c: PowerConsumer) => sum + (c.current_ma as number), 0);
-
-    // Find the highest-capacity output jack that matches this voltage
-    const matchingOutputs = outputJacks.filter(j => j.voltage != null && voltagesCompatible(j.voltage, voltage));
-    const maxOutputMa = matchingOutputs.length > 0
-      ? Math.max(...matchingOutputs.map(j => j.current_ma ?? 0))
-      : null;
-
-    // Only suggest if combined draw fits within an output
-    if (maxOutputMa != null && combinedMa <= maxOutputMa) {
-      groups.push({ voltage, polarity, connector_type, consumers: members, combined_ma: combinedMa, max_output_ma: maxOutputMa });
-    }
-  }
-
-  return groups;
-}
-
-// --- Port assignment types and algorithm ---
-
-interface TaggedOutputJack extends Jack {
-  supplyName: string;
-  portIndex: number;
-}
-
-interface PortAssignment {
-  consumer: PowerConsumer;
-  jack: TaggedOutputJack;
-  notes: string[];
-}
-
-interface AssignmentResult {
-  assignments: PortAssignment[];
-  unassigned: PowerConsumer[];
-}
-
-/**
- * Greedy assignment: sort consumers by highest current draw (most constrained first),
- * then assign each to the best compatible output jack.
- */
-function assignPedalsToOutputs(
-  consumers: PowerConsumer[],
-  supplies: PowerSupplyInfo[],
-): AssignmentResult {
-  // Build tagged output jacks with supply name and port index
-  const availableJacks: TaggedOutputJack[] = [];
-  for (const supply of supplies) {
-    supply.output_jacks.forEach((jack, idx) => {
-      availableJacks.push({
-        ...jack,
-        supplyName: `${supply.manufacturer} ${supply.model}`,
-        portIndex: idx + 1,
-      });
-    });
-  }
-
-  // Sort consumers by highest current draw first (unknowns last)
-  const sorted = [...consumers].sort((a, b) => (b.current_ma ?? 0) - (a.current_ma ?? 0));
-
-  const assigned = new Set<number>(); // jack IDs already used
-  const assignments: PortAssignment[] = [];
-  const unassigned: PowerConsumer[] = [];
-
-  for (const consumer of sorted) {
-    // Find compatible jacks
-    type Candidate = { jack: TaggedOutputJack; score: number; notes: string[] };
-    const candidates: Candidate[] = [];
-
-    for (const jack of availableJacks) {
-      if (assigned.has(jack.id)) continue;
-
-      // Hard constraint: voltage must be compatible (if both known)
-      if (consumer.voltage != null && jack.voltage != null) {
-        if (!voltagesCompatible(jack.voltage, consumer.voltage)) continue;
-      }
-
-      // Hard constraint: current capacity must be sufficient (if both known)
-      if (consumer.current_ma != null && jack.current_ma != null) {
-        if (jack.current_ma < consumer.current_ma) continue;
-      }
-
-      let score = 0;
-      const notes: string[] = [];
-
-      // Prefer isolated outputs
-      if (jack.is_isolated) score += 100;
-
-      // Prefer exact voltage match
-      if (consumer.voltage != null && jack.voltage != null) {
-        if (voltagesCompatible(jack.voltage, consumer.voltage)) score += 50;
-      }
-
-      // Polarity match
-      if (consumer.polarity != null && jack.polarity != null) {
-        if (normalizePolarity(consumer.polarity) === normalizePolarity(jack.polarity)) {
-          score += 30;
-        } else {
-          notes.push(`Needs polarity adapter (${consumer.polarity} pedal, ${jack.polarity} output)`);
-        }
-      }
-
-      // Connector match
-      if (consumer.connector_type != null && jack.connector_type != null) {
-        if (normalizeConnector(consumer.connector_type) === normalizeConnector(jack.connector_type)) {
-          score += 20;
-        } else {
-          notes.push(`Needs connector adapter (${consumer.connector_type} pedal, ${jack.connector_type} output)`);
-        }
-      }
-
-      // Prefer tighter headroom (less wasted capacity)
-      if (consumer.current_ma != null && jack.current_ma != null) {
-        const headroom = jack.current_ma - consumer.current_ma;
-        score += Math.max(0, 10 - Math.floor(headroom / 100));
-      }
-
-      candidates.push({ jack, score, notes });
-    }
-
-    if (candidates.length > 0) {
-      candidates.sort((a, b) => b.score - a.score);
-      const best = candidates[0];
-      assigned.add(best.jack.id);
-      assignments.push({ consumer, jack: best.jack, notes: best.notes });
-    } else {
-      unassigned.push(consumer);
-    }
-  }
-
-  return { assignments, unassigned };
-}
-
-/** Build the "See all compatible power supplies" link URL */
-function buildSupplyLinkUrl(
-  totalDraw: number,
-  consumerCount: number,
-  highestDrawMa: number | null,
-  uniqueVoltages: string[],
-): string {
-  const params = new URLSearchParams();
-  if (totalDraw > 0) params.set('minCurrent', String(totalDraw));
-  if (consumerCount > 0) params.set('minOutputs', String(consumerCount));
-  if (highestDrawMa != null && highestDrawMa > 0) params.set('minOutputCurrent', String(highestDrawMa));
-  if (uniqueVoltages.length > 0) params.set('voltages', uniqueVoltages.join(','));
-  const qs = params.toString();
-  return qs ? `/power-supplies?${qs}` : '/power-supplies';
-}
-
 const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
   const [showAssignments, setShowAssignments] = useState(false);
 
-  // Separate consumers from suppliers
-  const consumers: PowerConsumer[] = [];
-  const supplies: PowerSupplyInfo[] = [];
-
-  for (const row of rows) {
-    if (row.product_type === 'power_supply') {
-      supplies.push({
-        manufacturer: row.manufacturer,
-        model: row.model,
-        total_current_ma: (row.detail.total_current_ma as number) ?? null,
-        total_output_count: (row.detail.total_output_count as number) ?? null,
-        isolated_output_count: (row.detail.isolated_output_count as number) ?? null,
-        supply_type: (row.detail.supply_type as string) ?? null,
-        available_voltages: (row.detail.available_voltages as string) ?? null,
-        mounting_type: (row.detail.mounting_type as string) ?? null,
-        output_jacks: getPowerOutputJacks(row),
-      });
-    } else {
-      const powerJack = getPowerInputJack(row);
-      if (powerJack || row.jacks.some(j => j.category === 'power' && j.direction === 'input')) {
-        consumers.push({
-          manufacturer: row.manufacturer,
-          model: row.model,
-          current_ma: powerJack?.current_ma ?? null,
-          voltage: powerJack?.voltage ?? null,
-          polarity: powerJack?.polarity ?? null,
-          connector_type: powerJack?.connector_type ?? null,
-        });
-      }
-    }
-  }
+  const {
+    consumers,
+    supplies,
+    unknownConsumers,
+    totalDraw,
+    highestDraw,
+    totalCapacity,
+    status,
+    headroom,
+    headroomPct,
+    uniqueVoltages,
+    totalOutputCount,
+    allOutputJacks,
+  } = extractPowerData(rows);
 
   // No power consumers at all — nothing to show
   if (consumers.length === 0) return null;
 
-  const knownConsumers = consumers.filter(c => c.current_ma != null);
-  const unknownConsumers = consumers.filter(c => c.current_ma == null);
-  const totalDraw = knownConsumers.reduce((sum, c) => sum + (c.current_ma as number), 0);
-  const highestDraw = knownConsumers.length > 0
-    ? knownConsumers.reduce((max, c) => (c.current_ma as number) > (max.current_ma as number) ? c : max)
-    : null;
   const highestDrawMa = highestDraw ? (highestDraw.current_ma as number) : null;
-
-  // Unique voltages needed
-  const uniqueVoltages = Array.from(
-    new Set(consumers.map(c => c.voltage).filter((v): v is string => v != null))
-  ).sort();
-
-  const totalCapacity = supplies.reduce((sum, s) => sum + (s.total_current_ma ?? 0), 0);
   const hasSupply = supplies.length > 0;
   const knownSupplies = supplies.filter(s => s.total_current_ma != null);
-
-  // Combined supply stats
-  const totalOutputCount = supplies.reduce((sum, s) => sum + (s.total_output_count ?? 0), 0);
-  const allOutputJacks = supplies.flatMap(s => s.output_jacks);
-
-  // Determine state
-  let status: 'no-supply' | 'insufficient' | 'sufficient';
-  if (!hasSupply) {
-    status = 'no-supply';
-  } else if (totalCapacity < totalDraw) {
-    status = 'insufficient';
-  } else {
-    status = 'sufficient';
-  }
-
-  const headroom = totalCapacity - totalDraw;
-  const headroomPct = totalCapacity > 0 ? Math.round((headroom / totalCapacity) * 100) : 0;
 
   // Build smart link URL
   const supplyLinkUrl = buildSupplyLinkUrl(totalDraw, consumers.length, highestDrawMa, uniqueVoltages);
@@ -345,7 +51,6 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
     // 1. Output count warning
     const outputDiff = totalOutputCount - consumers.length;
     if (outputDiff < 0) {
-      // Fewer outputs than pedals
       const daisyGroups = computeDaisyChainGroups(consumers, allOutputJacks);
       warnings.push(
         <div key="output-count" className="power-budget__warning power-budget__warning--warn">

--- a/apps/web/src/components/Workbench/PowerView.tsx
+++ b/apps/web/src/components/Workbench/PowerView.tsx
@@ -1,0 +1,548 @@
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useWorkbench, PowerConnection } from '../../context/WorkbenchContext';
+import { WorkbenchRow } from './WorkbenchTable';
+import {
+  extractPowerData,
+  getPowerInputJack,
+  getPowerOutputJacks,
+  assignPedalsToOutputs,
+} from '../../utils/powerAssignment';
+import { validateConnection, ConnectionValidation } from '../../utils/powerUtils';
+import { Jack } from '../../utils/transformers';
+import CanvasBase from './CanvasBase';
+import ProductCard, { CARD_WIDTH, CARD_HEIGHT } from './ProductCard';
+import PortDot from './PortDot';
+import ConnectionLine from './ConnectionLine';
+import Konva from 'konva';
+
+const VIEW_KEY = 'power';
+
+const PORT_SPACING = 18;
+const PORT_HEIGHT_EXTRA = PORT_SPACING;
+const PORT_START_Y = CARD_HEIGHT - 10;
+
+const SUPPLY_X = 40;
+const CONSUMER_X = 500;
+const VERTICAL_GAP = 20;
+
+interface PowerViewProps {
+  rows: WorkbenchRow[];
+}
+
+function supplyCardHeight(outputCount: number): number {
+  if (outputCount <= 0) return CARD_HEIGHT;
+  return CARD_HEIGHT + outputCount * PORT_HEIGHT_EXTRA;
+}
+
+/** Local interaction state for connection creation */
+interface PendingConnection {
+  jackId: number;
+  productId: number;
+  direction: 'output' | 'input';
+}
+
+const PowerView = ({ rows }: PowerViewProps) => {
+  const {
+    getViewPositions,
+    updateViewPosition,
+    addPowerConnection,
+    removePowerConnection,
+    setPowerConnections,
+    acknowledgeWarning,
+    activeWorkbench,
+  } = useWorkbench();
+
+  const savedPositions = getViewPositions(VIEW_KEY);
+  const powerData = extractPowerData(rows);
+  const connections = activeWorkbench.powerConnections ?? [];
+
+  // Interaction state
+  const [pendingSource, setPendingSource] = useState<PendingConnection | null>(null);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+  const [warningPopover, setWarningPopover] = useState<{
+    connId: string;
+    warnings: string[];
+    x: number;
+    y: number;
+  } | null>(null);
+
+  // Build lookups
+  const rowMap = useMemo(() => {
+    const map = new Map<number, WorkbenchRow>();
+    for (const row of rows) map.set(row.id, row);
+    return map;
+  }, [rows]);
+
+  // Jack lookup: jackId → Jack object
+  const jackMap = useMemo(() => {
+    const map = new Map<number, Jack>();
+    for (const row of rows) {
+      for (const jack of row.jacks) {
+        map.set(jack.id, jack);
+      }
+    }
+    return map;
+  }, [rows]);
+
+  // Jack → product lookup
+  const jackToProduct = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const row of rows) {
+      for (const jack of row.jacks) {
+        map.set(jack.id, row.id);
+      }
+    }
+    return map;
+  }, [rows]);
+
+  // Supply and consumer position data
+  const supplyEntries = useMemo(() => {
+    let y = VERTICAL_GAP;
+    return powerData.supplies.map((supply) => {
+      const row = rowMap.get(supply.productId);
+      const outputJacks = row ? getPowerOutputJacks(row) : [];
+      const entry = { productId: supply.productId, x: SUPPLY_X, y, outputJacks };
+      y += supplyCardHeight(outputJacks.length) + VERTICAL_GAP;
+      return entry;
+    });
+  }, [powerData.supplies, rowMap]);
+
+  const consumerEntries = useMemo(() => {
+    let y = VERTICAL_GAP;
+    return powerData.consumers.map((consumer) => {
+      const row = rowMap.get(consumer.productId);
+      const inputJack = row ? getPowerInputJack(row) : undefined;
+      const entry = { productId: consumer.productId, x: CONSUMER_X, y, inputJack };
+      y += CARD_HEIGHT + VERTICAL_GAP;
+      return entry;
+    });
+  }, [powerData.consumers, rowMap]);
+
+  const getPosition = useCallback((productId: number, fallbackX: number, fallbackY: number) => {
+    const saved = savedPositions[String(productId)];
+    if (saved) return saved;
+    return { x: fallbackX, y: fallbackY };
+  }, [savedPositions]);
+
+  // Port absolute position lookup — maps jackId to canvas coordinates
+  const portPositions = useMemo(() => {
+    const map = new Map<number, { x: number; y: number }>();
+
+    for (const entry of supplyEntries) {
+      const pos = getPosition(entry.productId, entry.x, entry.y);
+      entry.outputJacks.forEach((jack, i) => {
+        map.set(jack.id, {
+          x: pos.x + CARD_WIDTH - 2,
+          y: pos.y + PORT_START_Y + i * PORT_SPACING,
+        });
+      });
+    }
+
+    for (const entry of consumerEntries) {
+      if (!entry.inputJack) continue;
+      const pos = getPosition(entry.productId, entry.x, entry.y);
+      map.set(entry.inputJack.id, {
+        x: pos.x + 2,
+        y: pos.y + CARD_HEIGHT / 2,
+      });
+    }
+
+    return map;
+  }, [supplyEntries, consumerEntries, getPosition]);
+
+  // Compute total current on each output jack (for daisy-chain validation)
+  const currentByOutput = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const conn of connections) {
+      const inputJack = jackMap.get(conn.targetJackId);
+      const currentMa = inputJack?.current_ma ?? 0;
+      map.set(conn.sourceJackId, (map.get(conn.sourceJackId) ?? 0) + currentMa);
+    }
+    return map;
+  }, [connections, jackMap]);
+
+  // Validate each connection
+  const connectionValidations = useMemo(() => {
+    const map = new Map<string, ConnectionValidation>();
+    for (const conn of connections) {
+      const outputJack = jackMap.get(conn.sourceJackId);
+      const inputJack = jackMap.get(conn.targetJackId);
+      if (outputJack && inputJack) {
+        map.set(conn.id, validateConnection(
+          outputJack,
+          inputJack,
+          currentByOutput.get(conn.sourceJackId),
+        ));
+      } else {
+        map.set(conn.id, { status: 'valid', warnings: [] });
+      }
+    }
+    return map;
+  }, [connections, jackMap, currentByOutput]);
+
+  const handleDragEnd = (productId: number, x: number, y: number) => {
+    updateViewPosition(VIEW_KEY, productId, x, y);
+  };
+
+  // --- Connection interaction ---
+
+  const handlePortClick = useCallback((jackId: number) => {
+    const productId = jackToProduct.get(jackId);
+    if (productId == null) return;
+
+    const jack = jackMap.get(jackId);
+    if (!jack) return;
+
+    const direction = jack.direction === 'output' ? 'output' as const : 'input' as const;
+
+    if (!pendingSource) {
+      // First click — start pending connection
+      setPendingSource({ jackId, productId, direction });
+      setMousePos(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+    } else if (pendingSource.jackId === jackId) {
+      // Clicked same port — cancel
+      setPendingSource(null);
+      setMousePos(null);
+    } else {
+      // Second click — attempt connection
+      if (pendingSource.direction === direction) {
+        // Can't connect output→output or input→input
+        setPendingSource(null);
+        setMousePos(null);
+        return;
+      }
+
+      const sourceJackId = direction === 'input' ? pendingSource.jackId : jackId;
+      const targetJackId = direction === 'input' ? jackId : pendingSource.jackId;
+      const sourceProductId = direction === 'input' ? pendingSource.productId : productId;
+      const targetProductId = direction === 'input' ? productId : pendingSource.productId;
+
+      addPowerConnection({
+        sourceJackId,
+        targetJackId,
+        sourceProductId,
+        targetProductId,
+      });
+      setPendingSource(null);
+      setMousePos(null);
+    }
+  }, [pendingSource, jackMap, jackToProduct, addPowerConnection]);
+
+  // Track mouse position for preview line (only while a connection is pending)
+  const handleStageMouseMove = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!pendingSource) return;
+    const stage = e.target.getStage();
+    if (stage) {
+      const pos = stage.getPointerPosition();
+      if (pos) setMousePos({ x: pos.x, y: pos.y });
+    }
+  }, [pendingSource]);
+
+  const handleStageClick = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    // Click on empty canvas — deselect and cancel pending
+    if (e.target === e.target.getStage()) {
+      setPendingSource(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+    }
+  }, []);
+
+  const handleConnectionClick = useCallback((connId: string) => {
+    const validation = connectionValidations.get(connId);
+    const conn = connections.find(c => c.id === connId);
+
+    if (validation && validation.warnings.length > 0 && conn) {
+      // Show warning popover
+      const sourcePos = portPositions.get(conn.sourceJackId);
+      const targetPos = portPositions.get(conn.targetJackId);
+      if (sourcePos && targetPos) {
+        setWarningPopover({
+          connId,
+          warnings: validation.warnings,
+          x: (sourcePos.x + targetPos.x) / 2,
+          y: (sourcePos.y + targetPos.y) / 2 - 30,
+        });
+      }
+    }
+
+    setSelectedConnectionId(connId);
+    setPendingSource(null);
+  }, [connectionValidations, connections, portPositions]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if ((e.key === 'Delete' || e.key === 'Backspace') && selectedConnectionId) {
+      removePowerConnection(selectedConnectionId);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+    }
+    if (e.key === 'Escape') {
+      setPendingSource(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+    }
+  }, [selectedConnectionId, removePowerConnection]);
+
+  // Register keyboard listener
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Auto-assign
+  const handleAutoAssign = useCallback(() => {
+    if (connections.length > 0 && !window.confirm('Replace existing connections?')) {
+      return;
+    }
+
+    const result = assignPedalsToOutputs(powerData.consumers, powerData.supplies);
+    const newConnections: PowerConnection[] = result.assignments.map((a) => {
+      // Find the consumer's power input jack
+      const consumerRow = rowMap.get(a.consumer.productId);
+      const inputJack = consumerRow ? getPowerInputJack(consumerRow) : undefined;
+
+      return {
+        id: crypto.randomUUID(),
+        sourceJackId: a.jack.id,
+        targetJackId: inputJack?.id ?? 0,
+        sourceProductId: a.jack.supplyProductId,
+        targetProductId: a.consumer.productId,
+      };
+    }).filter(c => c.targetJackId !== 0);
+
+    setPowerConnections(newConnections);
+    setSelectedConnectionId(null);
+    setWarningPopover(null);
+  }, [connections, powerData, rowMap, setPowerConnections]);
+
+  if (rows.length === 0) {
+    return (
+      <div className="workbench__canvas-placeholder">
+        Your workbench is empty. Add products from the catalog views.
+      </div>
+    );
+  }
+
+  if (powerData.consumers.length === 0 && powerData.supplies.length === 0) {
+    return (
+      <div className="workbench__canvas-placeholder">
+        No power supplies or powered products in this workbench.
+      </div>
+    );
+  }
+
+  // Pending source port position for preview line
+  const pendingSourcePos = pendingSource ? portPositions.get(pendingSource.jackId) : null;
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <CanvasBase
+        onStageClick={handleStageClick}
+        onStageMouseMove={handleStageMouseMove}
+      >
+        {/* Connection lines */}
+        {connections.map((conn) => {
+          const sourcePos = portPositions.get(conn.sourceJackId);
+          const targetPos = portPositions.get(conn.targetJackId);
+          if (!sourcePos || !targetPos) return null;
+
+          const validation = connectionValidations.get(conn.id) ?? { status: 'valid' as const, warnings: [] };
+          const isAcknowledged = (conn.acknowledgedWarnings?.length ?? 0) > 0 &&
+            validation.warnings.every(w => conn.acknowledgedWarnings?.includes(w));
+
+          return (
+            <ConnectionLine
+              key={conn.id}
+              sourceX={sourcePos.x}
+              sourceY={sourcePos.y}
+              targetX={targetPos.x}
+              targetY={targetPos.y}
+              status={validation.status}
+              acknowledged={isAcknowledged}
+              selected={selectedConnectionId === conn.id}
+              onClick={() => handleConnectionClick(conn.id)}
+            />
+          );
+        })}
+
+        {/* Preview line while creating connection */}
+        {pendingSource && pendingSourcePos && mousePos && (
+          <ConnectionLine
+            sourceX={pendingSourcePos.x}
+            sourceY={pendingSourcePos.y}
+            targetX={mousePos.x}
+            targetY={mousePos.y}
+            status="valid"
+          />
+        )}
+
+        {/* Supply cards with output port dots */}
+        {supplyEntries.map((entry) => {
+          const supply = powerData.supplies.find(s => s.productId === entry.productId)!;
+          const pos = getPosition(entry.productId, entry.x, entry.y);
+
+          return (
+            <ProductCard
+              key={entry.productId}
+              productType="power_supply"
+              manufacturer={supply.manufacturer}
+              model={supply.model}
+              x={pos.x}
+              y={pos.y}
+              onDragEnd={(x, y) => handleDragEnd(entry.productId, x, y)}
+              cardHeight={supplyCardHeight(entry.outputJacks.length)}
+            >
+              {entry.outputJacks.map((jack, i) => {
+                const label = [
+                  jack.voltage ?? '?V',
+                  jack.current_ma != null ? `${jack.current_ma}mA` : '',
+                ].filter(Boolean).join(' ');
+
+                return (
+                  <PortDot
+                    key={jack.id}
+                    x={CARD_WIDTH - 2}
+                    y={PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.id}
+                    label={label}
+                    direction="output"
+                    isolated={jack.is_isolated !== false}
+                    color={pendingSource?.jackId === jack.id ? '#fff' : '#6aaa6a'}
+                    onClick={handlePortClick}
+                  />
+                );
+              })}
+            </ProductCard>
+          );
+        })}
+
+        {/* Consumer cards with power input port dot */}
+        {consumerEntries.map((entry) => {
+          const consumer = powerData.consumers.find(c => c.productId === entry.productId)!;
+          const pos = getPosition(entry.productId, entry.x, entry.y);
+
+          return (
+            <ProductCard
+              key={entry.productId}
+              productType={rowMap.get(entry.productId)?.product_type ?? 'pedal'}
+              manufacturer={consumer.manufacturer}
+              model={consumer.model}
+              x={pos.x}
+              y={pos.y}
+              onDragEnd={(x, y) => handleDragEnd(entry.productId, x, y)}
+            >
+              {entry.inputJack && (
+                <PortDot
+                  x={2}
+                  y={CARD_HEIGHT / 2}
+                  jackId={entry.inputJack.id}
+                  label={[
+                    consumer.voltage ?? '?V',
+                    consumer.current_ma != null ? `${consumer.current_ma}mA` : '',
+                  ].filter(Boolean).join(' ')}
+                  direction="input"
+                  color={pendingSource?.jackId === entry.inputJack.id ? '#fff' : '#6a6aaa'}
+                  onClick={handlePortClick}
+                />
+              )}
+            </ProductCard>
+          );
+        })}
+      </CanvasBase>
+
+      {/* Canvas action buttons */}
+      <div className="workbench__power-actions">
+        {powerData.supplies.length > 0 && powerData.consumers.length > 0 && (
+          <button
+            className="workbench__power-action-btn"
+            onClick={handleAutoAssign}
+            title="Automatically assign pedals to power supply outputs"
+          >
+            Auto-assign
+          </button>
+        )}
+        {connections.length > 0 && (
+          <button
+            className="workbench__power-action-btn workbench__power-action-btn--danger"
+            onClick={() => {
+              if (window.confirm(`Clear all ${connections.length} connection${connections.length === 1 ? '' : 's'}?`)) {
+                setPowerConnections([]);
+                setSelectedConnectionId(null);
+                setWarningPopover(null);
+              }
+            }}
+            title="Remove all connections"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Floating delete button for selected connection */}
+      {selectedConnectionId && (() => {
+        const conn = connections.find(c => c.id === selectedConnectionId);
+        if (!conn) return null;
+        const srcPos = portPositions.get(conn.sourceJackId);
+        const tgtPos = portPositions.get(conn.targetJackId);
+        if (!srcPos || !tgtPos) return null;
+        return (
+          <button
+            className="workbench__power-delete-btn"
+            style={{
+              position: 'absolute',
+              left: (srcPos.x + tgtPos.x) / 2,
+              top: (srcPos.y + tgtPos.y) / 2,
+            }}
+            title="Delete connection"
+            onClick={() => {
+              removePowerConnection(selectedConnectionId);
+              setSelectedConnectionId(null);
+              setWarningPopover(null);
+            }}
+          >
+            ×
+          </button>
+        );
+      })()}
+
+      {/* Warning popover */}
+      {warningPopover && (
+        <div
+          className="workbench__power-popover"
+          style={{
+            position: 'absolute',
+            left: warningPopover.x,
+            top: warningPopover.y,
+          }}
+        >
+          <div className="workbench__power-popover-warnings">
+            {warningPopover.warnings.map((w, i) => (
+              <div key={i} className="workbench__power-popover-warning">{w}</div>
+            ))}
+          </div>
+          <button
+            className="workbench__power-popover-btn"
+            onClick={() => {
+              for (const w of warningPopover.warnings) {
+                acknowledgeWarning(warningPopover.connId, w);
+              }
+              setWarningPopover(null);
+            }}
+          >
+            I have this adapter
+          </button>
+          <button
+            className="workbench__power-popover-btn workbench__power-popover-btn--close"
+            onClick={() => setWarningPopover(null)}
+          >
+            Close
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PowerView;

--- a/apps/web/src/components/Workbench/ProductCard.tsx
+++ b/apps/web/src/components/Workbench/ProductCard.tsx
@@ -1,0 +1,115 @@
+import { Group, Rect, Text } from 'react-konva';
+import Konva from 'konva';
+import { ProductType } from '../../context/WorkbenchContext';
+import { ReactNode } from 'react';
+
+/** Color scheme per product type, matching the existing .type-badge SCSS colors */
+const TYPE_COLORS: Record<ProductType, { fill: string; stroke: string; text: string }> = {
+  pedal:           { fill: '#1a2a1a', stroke: '#2a3a2a', text: '#6aaa6a' },
+  power_supply:    { fill: '#2a2a1a', stroke: '#3a3a2a', text: '#aaaa5a' },
+  pedalboard:      { fill: '#1a1a2a', stroke: '#2a2a3a', text: '#6a6aaa' },
+  midi_controller: { fill: '#2a1a2a', stroke: '#3a2a3a', text: '#aa6aaa' },
+  utility:         { fill: '#1a2a2a', stroke: '#2a3a3a', text: '#6aaaaa' },
+};
+
+export const CARD_WIDTH = 140;
+export const CARD_HEIGHT = 64;
+
+interface ProductCardProps {
+  productType: ProductType;
+  manufacturer: string;
+  model: string;
+  x: number;
+  y: number;
+  onDragEnd: (x: number, y: number) => void;
+  onClick?: () => void;
+  selected?: boolean;
+  children?: ReactNode;
+  /** Override card height (e.g., taller for supply cards with many ports) */
+  cardHeight?: number;
+}
+
+/**
+ * A draggable product card rendered on the Konva canvas.
+ * Shows manufacturer name, model, and a colored border based on product type.
+ */
+const ProductCard = ({
+  productType,
+  manufacturer,
+  model,
+  x,
+  y,
+  onDragEnd,
+  onClick,
+  selected = false,
+  children,
+  cardHeight,
+}: ProductCardProps) => {
+  const colors = TYPE_COLORS[productType] || TYPE_COLORS.pedal;
+  const height = cardHeight ?? CARD_HEIGHT;
+
+  return (
+    <Group
+      x={x}
+      y={y}
+      draggable
+      onDragEnd={(e: Konva.KonvaEventObject<DragEvent>) => {
+        onDragEnd(e.target.x(), e.target.y());
+      }}
+      onClick={onClick}
+      onTap={onClick}
+    >
+      {/* Card background */}
+      <Rect
+        width={CARD_WIDTH}
+        height={height}
+        fill={colors.fill}
+        stroke={selected ? '#e0e0e0' : colors.stroke}
+        strokeWidth={selected ? 2 : 1}
+        cornerRadius={4}
+        shadowColor={selected ? '#e0e0e0' : undefined}
+        shadowBlur={selected ? 6 : 0}
+        shadowOpacity={selected ? 0.3 : 0}
+      />
+      {/* Manufacturer */}
+      <Text
+        x={8}
+        y={8}
+        width={CARD_WIDTH - 16}
+        text={manufacturer}
+        fontSize={11}
+        fontFamily="'Helvetica Neue', sans-serif"
+        fontStyle="bold"
+        fill="#f0f0f0"
+        ellipsis
+        wrap="none"
+      />
+      {/* Model */}
+      <Text
+        x={8}
+        y={24}
+        width={CARD_WIDTH - 16}
+        text={model}
+        fontSize={11}
+        fontFamily="'SF Mono', 'Fira Code', monospace"
+        fill={colors.text}
+        ellipsis
+        wrap="none"
+      />
+      {/* Type label */}
+      <Text
+        x={8}
+        y={44}
+        width={CARD_WIDTH - 16}
+        text={productType.replace(/_/g, ' ')}
+        fontSize={9}
+        fontFamily="monospace"
+        fill="#555"
+        textTransform="uppercase"
+      />
+      {children}
+    </Group>
+  );
+};
+
+export default ProductCard;

--- a/apps/web/src/components/Workbench/ViewNav.tsx
+++ b/apps/web/src/components/Workbench/ViewNav.tsx
@@ -1,0 +1,45 @@
+export type ViewMode = 'layout' | 'audio' | 'power' | 'midi' | 'control' | 'list';
+
+interface ViewTab {
+  key: ViewMode;
+  label: string;
+  enabled: boolean;
+}
+
+const VIEW_TABS: ViewTab[] = [
+  { key: 'layout', label: 'Layout', enabled: true },
+  { key: 'audio', label: 'Audio', enabled: false },
+  { key: 'power', label: 'Power', enabled: true },
+  { key: 'midi', label: 'MIDI', enabled: false },
+  { key: 'control', label: 'Control', enabled: false },
+  { key: 'list', label: 'List', enabled: true },
+];
+
+interface ViewNavProps {
+  activeView: ViewMode;
+  onViewChange: (view: ViewMode) => void;
+}
+
+const ViewNav = ({ activeView, onViewChange }: ViewNavProps) => {
+  return (
+    <div className="workbench__view-nav">
+      {VIEW_TABS.map(tab => (
+        <button
+          key={tab.key}
+          className={
+            'workbench__view-tab' +
+            (activeView === tab.key ? ' workbench__view-tab--active' : '') +
+            (!tab.enabled ? ' workbench__view-tab--disabled' : '')
+          }
+          onClick={() => tab.enabled && onViewChange(tab.key)}
+          title={tab.enabled ? undefined : 'Coming soon'}
+          disabled={!tab.enabled}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ViewNav;

--- a/apps/web/src/components/Workbench/index.scss
+++ b/apps/web/src/components/Workbench/index.scss
@@ -128,6 +128,42 @@
     margin-top: 10px;
   }
 
+  &__view-nav {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid #2a2a2a;
+    flex-shrink: 0;
+  }
+
+  &__view-tab {
+    padding: 8px 16px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    color: #666;
+    cursor: pointer;
+    border: none;
+    border-bottom: 2px solid transparent;
+    background: none;
+    font-family: monospace;
+    transition: all 0.15s;
+
+    &:hover:not(&--disabled) {
+      color: #aaa;
+    }
+
+    &--active {
+      color: #e0e0e0;
+      border-bottom-color: #e0e0e0;
+    }
+
+    &--disabled {
+      color: #444;
+      cursor: default;
+    }
+  }
+
   &__body {
     display: flex;
     gap: 0;
@@ -142,6 +178,136 @@
     flex: 1;
     min-width: 0;
     min-height: 0;
+
+    &--canvas {
+      overflow: hidden;
+      position: relative;
+    }
+  }
+
+  &__canvas-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: #555;
+    font-size: 14px;
+  }
+
+  &__power-actions {
+    position: absolute;
+    bottom: 16px;
+    right: 16px;
+    display: flex;
+    gap: 8px;
+    z-index: 10;
+  }
+
+  &__power-action-btn {
+    padding: 8px 16px;
+    border-radius: 5px;
+    border: 1px solid #333;
+    background: #1a1a1a;
+    color: #999;
+    font-size: 12px;
+    font-family: monospace;
+    cursor: pointer;
+    transition: all 0.15s;
+
+    &:hover {
+      border-color: #555;
+      color: #ccc;
+      background: #222;
+    }
+
+    &--danger {
+      color: #cc6060;
+      border-color: #4a2a2a;
+
+      &:hover {
+        background: #2e1a1a;
+        border-color: #8b4444;
+        color: #e07070;
+      }
+    }
+  }
+
+  &__power-delete-btn {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid #8b4444;
+    background: #2e1a1a;
+    color: #cc6060;
+    font-size: 16px;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 15;
+    transform: translate(-50%, -50%);
+    transition: all 0.15s;
+    padding: 0;
+
+    &:hover {
+      background: #4a2020;
+      border-color: #cc6060;
+      color: #ff8080;
+    }
+  }
+
+  &__power-popover {
+    background: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 6px;
+    padding: 10px 12px;
+    z-index: 20;
+    max-width: 300px;
+    font-size: 11px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    transform: translateX(-50%);
+  }
+
+  &__power-popover-warnings {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 8px;
+  }
+
+  &__power-popover-warning {
+    color: #d4a55a;
+    line-height: 1.4;
+  }
+
+  &__power-popover-btn {
+    padding: 4px 10px;
+    border-radius: 3px;
+    border: 1px solid #444;
+    background: #2a2a1a;
+    color: #d4a55a;
+    font-size: 10px;
+    font-family: monospace;
+    cursor: pointer;
+    margin-right: 6px;
+    transition: all 0.15s;
+
+    &:hover {
+      background: #3a3a2a;
+      border-color: #666;
+    }
+
+    &--close {
+      background: #1a1a1a;
+      color: #888;
+      border-color: #333;
+
+      &:hover {
+        background: #222;
+        color: #bbb;
+      }
+    }
   }
 
   &__table-wrapper {

--- a/apps/web/src/components/Workbench/index.tsx
+++ b/apps/web/src/components/Workbench/index.tsx
@@ -3,6 +3,9 @@ import { useWorkbench } from '../../context/WorkbenchContext';
 import WorkbenchTableView, { useWorkbenchProducts, WorkbenchRow } from './WorkbenchTable';
 import DetailPanel from './DetailPanel';
 import InsightsSidebar from './InsightsSidebar';
+import ViewNav, { ViewMode } from './ViewNav';
+import LayoutView from './LayoutView';
+import PowerView from './PowerView';
 import './index.scss';
 
 const Workbench = () => {
@@ -17,6 +20,7 @@ const Workbench = () => {
 
   const { rows, loading, error } = useWorkbenchProducts();
 
+  const [activeView, setActiveView] = useState<ViewMode>('list');
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -67,6 +71,52 @@ const Workbench = () => {
 
   const handleRowClick = (row: WorkbenchRow) => {
     setSelectedRow(prev => prev?.id === row.id ? null : row);
+  };
+
+  const renderActiveView = () => {
+    switch (activeView) {
+      case 'list':
+        return (
+          <>
+            <div className="workbench__content">
+              <WorkbenchTableView
+                rows={rows}
+                loading={loading}
+                error={error}
+                onRowClick={handleRowClick}
+              />
+            </div>
+
+            {!loading && rows.length > 0 && (
+              <InsightsSidebar rows={rows} />
+            )}
+
+            {selectedRow && (
+              <DetailPanel
+                row={selectedRow}
+                onClose={() => setSelectedRow(null)}
+              />
+            )}
+          </>
+        );
+
+      case 'layout':
+        return (
+          <div className="workbench__content workbench__content--canvas">
+            <LayoutView rows={rows} />
+          </div>
+        );
+
+      case 'power':
+        return (
+          <div className="workbench__content workbench__content--canvas">
+            <PowerView rows={rows} />
+          </div>
+        );
+
+      default:
+        return null;
+    }
   };
 
   return (
@@ -145,26 +195,10 @@ const Workbench = () => {
         )}
       </div>
 
+      <ViewNav activeView={activeView} onViewChange={setActiveView} />
+
       <div className="workbench__body">
-        <div className="workbench__content">
-          <WorkbenchTableView
-            rows={rows}
-            loading={loading}
-            error={error}
-            onRowClick={handleRowClick}
-          />
-        </div>
-
-        {!loading && rows.length > 0 && (
-          <InsightsSidebar rows={rows} />
-        )}
-
-        {selectedRow && (
-          <DetailPanel
-            row={selectedRow}
-            onClose={() => setSelectedRow(null)}
-          />
-        )}
+        {renderActiveView()}
       </div>
     </div>
   );

--- a/apps/web/src/types/power.ts
+++ b/apps/web/src/types/power.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared type definitions for power budget calculations.
+ * Used by PowerBudgetInsight (sidebar), PowerView (canvas), and powerAssignment utils.
+ */
+
+import { Jack } from '../utils/transformers';
+
+export interface PowerConsumer {
+  productId: number;
+  manufacturer: string;
+  model: string;
+  current_ma: number | null;
+  voltage: string | null;
+  polarity: string | null;
+  connector_type: string | null;
+}
+
+export interface PowerSupplyInfo {
+  productId: number;
+  manufacturer: string;
+  model: string;
+  total_current_ma: number | null;
+  total_output_count: number | null;
+  isolated_output_count: number | null;
+  supply_type: string | null;
+  available_voltages: string | null;
+  mounting_type: string | null;
+  output_jacks: Jack[];
+}
+
+export interface TaggedOutputJack extends Jack {
+  supplyName: string;
+  supplyProductId: number;
+  portIndex: number;
+}
+
+export interface PortAssignment {
+  consumer: PowerConsumer;
+  jack: TaggedOutputJack;
+  notes: string[];
+}
+
+export interface AssignmentResult {
+  assignments: PortAssignment[];
+  unassigned: PowerConsumer[];
+}
+
+export interface DaisyChainGroup {
+  voltage: string;
+  polarity: string;
+  connector_type: string;
+  consumers: PowerConsumer[];
+  combined_ma: number;
+  max_output_ma: number | null;
+}
+
+export type PowerBudgetStatus = 'no-supply' | 'insufficient' | 'sufficient';
+
+export interface PowerBudgetData {
+  consumers: PowerConsumer[];
+  supplies: PowerSupplyInfo[];
+  knownConsumers: PowerConsumer[];
+  unknownConsumers: PowerConsumer[];
+  totalDraw: number;
+  highestDraw: PowerConsumer | null;
+  totalCapacity: number;
+  status: PowerBudgetStatus;
+  headroom: number;
+  headroomPct: number;
+  uniqueVoltages: string[];
+  totalOutputCount: number;
+  allOutputJacks: Jack[];
+}

--- a/apps/web/src/utils/powerAssignment.ts
+++ b/apps/web/src/utils/powerAssignment.ts
@@ -1,0 +1,315 @@
+/**
+ * Power budget calculation utilities.
+ * Extracted from PowerBudgetInsight.tsx for reuse in the Power canvas view.
+ */
+
+import { Jack } from './transformers';
+import { normalizePolarity, normalizeConnector, voltagesCompatible } from './powerUtils';
+import {
+  PowerConsumer,
+  PowerSupplyInfo,
+  TaggedOutputJack,
+  PortAssignment,
+  AssignmentResult,
+  DaisyChainGroup,
+  PowerBudgetData,
+} from '../types/power';
+
+// Re-export types for convenience
+export type {
+  PowerConsumer,
+  PowerSupplyInfo,
+  TaggedOutputJack,
+  PortAssignment,
+  AssignmentResult,
+  DaisyChainGroup,
+  PowerBudgetData,
+};
+
+/** Rows must have this shape — matches WorkbenchRow from WorkbenchTable */
+interface PowerRow {
+  id: number;
+  product_type: string;
+  manufacturer: string;
+  model: string;
+  jacks: Jack[];
+  detail: Record<string, unknown>;
+}
+
+export function getPowerInputJack(row: PowerRow): Jack | undefined {
+  return row.jacks.find(j => j.category === 'power' && j.direction === 'input');
+}
+
+export function getPowerOutputJacks(row: PowerRow): Jack[] {
+  return row.jacks.filter(j => j.category === 'power' && j.direction === 'output');
+}
+
+export function formatMa(ma: number): string {
+  return `${ma.toLocaleString()}mA`;
+}
+
+/** Find the majority polarity among supply output jacks (normalized) */
+export function getMajorityPolarity(jacks: Jack[]): string | null {
+  const counts: Record<string, number> = {};
+  for (const j of jacks) {
+    if (j.polarity) {
+      const norm = normalizePolarity(j.polarity);
+      counts[norm] = (counts[norm] || 0) + 1;
+    }
+  }
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [pol, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      best = pol;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** Find the majority connector type among supply output jacks (normalized) */
+export function getMajorityConnector(jacks: Jack[]): string | null {
+  const counts: Record<string, number> = {};
+  for (const j of jacks) {
+    if (j.connector_type) {
+      const norm = normalizeConnector(j.connector_type);
+      counts[norm] = (counts[norm] || 0) + 1;
+    }
+  }
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [ct, count] of Object.entries(counts)) {
+    if (count > bestCount) {
+      best = ct;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/**
+ * When the supply has fewer outputs than pedals, identify groups of
+ * electrically compatible pedals that could share an output via daisy-chain.
+ */
+export function computeDaisyChainGroups(
+  consumers: PowerConsumer[],
+  outputJacks: Jack[],
+): DaisyChainGroup[] {
+  const eligible = consumers.filter(
+    c => c.current_ma != null && c.voltage != null && c.polarity != null && c.connector_type != null,
+  );
+
+  const groupMap = new Map<string, PowerConsumer[]>();
+  for (const c of eligible) {
+    const key = `${c.voltage}|${c.polarity}|${c.connector_type}`;
+    const arr = groupMap.get(key);
+    if (arr) arr.push(c);
+    else groupMap.set(key, [c]);
+  }
+
+  const groups: DaisyChainGroup[] = [];
+  for (const [key, members] of Array.from(groupMap)) {
+    if (members.length < 2) continue;
+    const [voltage, polarity, connector_type] = key.split('|');
+    const combinedMa = members.reduce((sum: number, c: PowerConsumer) => sum + (c.current_ma as number), 0);
+
+    const matchingOutputs = outputJacks.filter(j => j.voltage != null && voltagesCompatible(j.voltage, voltage));
+    const maxOutputMa = matchingOutputs.length > 0
+      ? Math.max(...matchingOutputs.map(j => j.current_ma ?? 0))
+      : null;
+
+    if (maxOutputMa != null && combinedMa <= maxOutputMa) {
+      groups.push({ voltage, polarity, connector_type, consumers: members, combined_ma: combinedMa, max_output_ma: maxOutputMa });
+    }
+  }
+
+  return groups;
+}
+
+/**
+ * Greedy assignment: sort consumers by highest current draw (most constrained first),
+ * then assign each to the best compatible output jack.
+ */
+export function assignPedalsToOutputs(
+  consumers: PowerConsumer[],
+  supplies: PowerSupplyInfo[],
+): AssignmentResult {
+  const availableJacks: TaggedOutputJack[] = [];
+  for (const supply of supplies) {
+    supply.output_jacks.forEach((jack, idx) => {
+      availableJacks.push({
+        ...jack,
+        supplyName: `${supply.manufacturer} ${supply.model}`,
+        supplyProductId: supply.productId,
+        portIndex: idx + 1,
+      });
+    });
+  }
+
+  const sorted = [...consumers].sort((a, b) => (b.current_ma ?? 0) - (a.current_ma ?? 0));
+
+  const assigned = new Set<number>();
+  const assignments: PortAssignment[] = [];
+  const unassigned: PowerConsumer[] = [];
+
+  for (const consumer of sorted) {
+    type Candidate = { jack: TaggedOutputJack; score: number; notes: string[] };
+    const candidates: Candidate[] = [];
+
+    for (const jack of availableJacks) {
+      if (assigned.has(jack.id)) continue;
+
+      if (consumer.voltage != null && jack.voltage != null) {
+        if (!voltagesCompatible(jack.voltage, consumer.voltage)) continue;
+      }
+
+      if (consumer.current_ma != null && jack.current_ma != null) {
+        if (jack.current_ma < consumer.current_ma) continue;
+      }
+
+      let score = 0;
+      const notes: string[] = [];
+
+      if (jack.is_isolated) score += 100;
+
+      if (consumer.voltage != null && jack.voltage != null) {
+        if (voltagesCompatible(jack.voltage, consumer.voltage)) score += 50;
+      }
+
+      if (consumer.polarity != null && jack.polarity != null) {
+        if (normalizePolarity(consumer.polarity) === normalizePolarity(jack.polarity)) {
+          score += 30;
+        } else {
+          notes.push(`Needs polarity adapter (${consumer.polarity} pedal, ${jack.polarity} output)`);
+        }
+      }
+
+      if (consumer.connector_type != null && jack.connector_type != null) {
+        if (normalizeConnector(consumer.connector_type) === normalizeConnector(jack.connector_type)) {
+          score += 20;
+        } else {
+          notes.push(`Needs connector adapter (${consumer.connector_type} pedal, ${jack.connector_type} output)`);
+        }
+      }
+
+      if (consumer.current_ma != null && jack.current_ma != null) {
+        const headroom = jack.current_ma - consumer.current_ma;
+        score += Math.max(0, 10 - Math.floor(headroom / 100));
+      }
+
+      candidates.push({ jack, score, notes });
+    }
+
+    if (candidates.length > 0) {
+      candidates.sort((a, b) => b.score - a.score);
+      const best = candidates[0];
+      assigned.add(best.jack.id);
+      assignments.push({ consumer, jack: best.jack, notes: best.notes });
+    } else {
+      unassigned.push(consumer);
+    }
+  }
+
+  return { assignments, unassigned };
+}
+
+/** Build the "See all compatible power supplies" link URL */
+export function buildSupplyLinkUrl(
+  totalDraw: number,
+  consumerCount: number,
+  highestDrawMa: number | null,
+  uniqueVoltages: string[],
+): string {
+  const params = new URLSearchParams();
+  if (totalDraw > 0) params.set('minCurrent', String(totalDraw));
+  if (consumerCount > 0) params.set('minOutputs', String(consumerCount));
+  if (highestDrawMa != null && highestDrawMa > 0) params.set('minOutputCurrent', String(highestDrawMa));
+  if (uniqueVoltages.length > 0) params.set('voltages', uniqueVoltages.join(','));
+  const qs = params.toString();
+  return qs ? `/power-supplies?${qs}` : '/power-supplies';
+}
+
+/**
+ * Extract and compute all power budget data from workbench rows.
+ * Pure function — no React dependencies.
+ */
+export function extractPowerData(rows: PowerRow[]): PowerBudgetData {
+  const consumers: PowerConsumer[] = [];
+  const supplies: PowerSupplyInfo[] = [];
+
+  for (const row of rows) {
+    if (row.product_type === 'power_supply') {
+      supplies.push({
+        productId: row.id,
+        manufacturer: row.manufacturer,
+        model: row.model,
+        total_current_ma: (row.detail.total_current_ma as number) ?? null,
+        total_output_count: (row.detail.total_output_count as number) ?? null,
+        isolated_output_count: (row.detail.isolated_output_count as number) ?? null,
+        supply_type: (row.detail.supply_type as string) ?? null,
+        available_voltages: (row.detail.available_voltages as string) ?? null,
+        mounting_type: (row.detail.mounting_type as string) ?? null,
+        output_jacks: getPowerOutputJacks(row),
+      });
+    } else {
+      const powerJack = getPowerInputJack(row);
+      if (powerJack || row.jacks.some(j => j.category === 'power' && j.direction === 'input')) {
+        consumers.push({
+          productId: row.id,
+          manufacturer: row.manufacturer,
+          model: row.model,
+          current_ma: powerJack?.current_ma ?? null,
+          voltage: powerJack?.voltage ?? null,
+          polarity: powerJack?.polarity ?? null,
+          connector_type: powerJack?.connector_type ?? null,
+        });
+      }
+    }
+  }
+
+  const knownConsumers = consumers.filter(c => c.current_ma != null);
+  const unknownConsumers = consumers.filter(c => c.current_ma == null);
+  const totalDraw = knownConsumers.reduce((sum, c) => sum + (c.current_ma as number), 0);
+  const highestDraw = knownConsumers.length > 0
+    ? knownConsumers.reduce((max, c) => (c.current_ma as number) > (max.current_ma as number) ? c : max)
+    : null;
+
+  const uniqueVoltages = Array.from(
+    new Set(consumers.map(c => c.voltage).filter((v): v is string => v != null))
+  ).sort();
+
+  const totalCapacity = supplies.reduce((sum, s) => sum + (s.total_current_ma ?? 0), 0);
+  const hasSupply = supplies.length > 0;
+
+  let status: 'no-supply' | 'insufficient' | 'sufficient';
+  if (!hasSupply) {
+    status = 'no-supply';
+  } else if (totalCapacity < totalDraw) {
+    status = 'insufficient';
+  } else {
+    status = 'sufficient';
+  }
+
+  const headroom = totalCapacity - totalDraw;
+  const headroomPct = totalCapacity > 0 ? Math.round((headroom / totalCapacity) * 100) : 0;
+
+  const totalOutputCount = supplies.reduce((sum, s) => sum + (s.total_output_count ?? 0), 0);
+  const allOutputJacks = supplies.flatMap(s => s.output_jacks);
+
+  return {
+    consumers,
+    supplies,
+    knownConsumers,
+    unknownConsumers,
+    totalDraw,
+    highestDraw,
+    totalCapacity,
+    status,
+    headroom,
+    headroomPct,
+    uniqueVoltages,
+    totalOutputCount,
+    allOutputJacks,
+  };
+}

--- a/apps/web/webpack.common.js
+++ b/apps/web/webpack.common.js
@@ -47,6 +47,14 @@ module.exports = {
 	},
 	resolve: {
 		extensions: ['.tsx', '.ts', '.js', '.jsx', '.json'],
+		modules: [
+			path.resolve(__dirname, 'node_modules'),
+			path.resolve(__dirname, '../../node_modules'),
+			'node_modules',
+		],
+		alias: {
+			'konva': path.resolve(__dirname, '../../node_modules/konva'),
+		},
 	},
 	output: {
 		filename: 'bundle.js',

--- a/docs/plans/todo.md
+++ b/docs/plans/todo.md
@@ -74,6 +74,12 @@
 ## 11. Fixes and Improvements
 
 - [ ] Enable users to select multiple instances of the same pedal
+- [ ] Layout views improvements
+	- [ ] Make objects rotateable
+	- [ ] Make objects fit product dimensions
+	- [ ] Add a delete button to selected connection lines
+- [ ] Move to Docker for better development processes
+	- [ ] Update node and all packages to newer versions if Docker circumvents macOS limitations
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,12 @@
       "license": "ISC",
       "dependencies": {
         "@rjsf/core": "^4.2.0",
+        "konva": "^10.2.0",
         "node-polyfill-webpack-plugin": "^2.0.0",
         "react": "^18.2.0",
         "react-classlist": "^1.1.2",
         "react-dom": "^18.2.0",
+        "react-konva": "^18.2.14",
         "react-router-dom": "^6.3.0"
       },
       "devDependencies": {
@@ -1096,11 +1098,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
-    },
-    "apps/web/node_modules/@realm.io/common": {
-      "version": "0.1.4",
-      "extraneous": true,
-      "license": "SEE LICENSE IN LICENSE"
     },
     "apps/web/node_modules/@restart/hooks": {
       "version": "0.4.7",
@@ -2546,40 +2543,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "apps/web/node_modules/bson": {
-      "version": "4.6.4",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/buffer": {
-      "version": "5.7.1",
-      "extraneous": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "apps/web/node_modules/buffer-from": {
       "version": "1.1.2",
       "license": "MIT"
@@ -3188,11 +3151,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "apps/web/node_modules/csstype": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "apps/web/node_modules/data-urls": {
       "version": "3.0.2",
       "dev": true,
@@ -3338,11 +3296,6 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
-    },
-    "apps/web/node_modules/detect-browser": {
-      "version": "5.3.0",
-      "extraneous": true,
-      "license": "MIT"
     },
     "apps/web/node_modules/detect-newline": {
       "version": "3.1.0",
@@ -3585,14 +3538,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "apps/web/node_modules/encoding": {
-      "version": "0.1.13",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
       }
     },
     "apps/web/node_modules/enhanced-resolve": {
@@ -6218,15 +6163,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "apps/web/node_modules/js-base64": {
-      "version": "3.7.2",
-      "extraneous": true,
-      "license": "BSD-3-Clause"
-    },
-    "apps/web/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
-    },
     "apps/web/node_modules/js-yaml": {
       "version": "3.14.1",
       "dev": true,
@@ -6413,16 +6349,6 @@
       "version": "4.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/web/node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "apps/web/node_modules/lower-case": {
       "version": "2.0.2",
@@ -6672,44 +6598,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "apps/web/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "extraneous": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "extraneous": true,
-      "license": "BSD-2-Clause"
-    },
-    "apps/web/node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "apps/web/node_modules/node-forge": {
@@ -7524,16 +7412,6 @@
         "node": ">=0.10.0"
       }
     },
-    "apps/web/node_modules/react": {
-      "version": "18.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "apps/web/node_modules/react-bootstrap": {
       "version": "2.4.0",
       "dev": true,
@@ -7583,17 +7461,6 @@
     "apps/web/node_modules/react-classlist": {
       "version": "1.1.2",
       "license": "ISC"
-    },
-    "apps/web/node_modules/react-dom": {
-      "version": "18.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
     },
     "apps/web/node_modules/react-is": {
       "version": "17.0.2",
@@ -7672,21 +7539,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "apps/web/node_modules/realm-web": {
-      "version": "1.7.0",
-      "extraneous": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@realm.io/common": "^0.1.1",
-        "bson": "^4.5.4",
-        "detect-browser": "^5.2.1",
-        "js-base64": "^3.7.2"
-      },
-      "optionalDependencies": {
-        "abort-controller": "^3.0.0",
-        "node-fetch": "^2.6.0"
       }
     },
     "apps/web/node_modules/rechoir": {
@@ -7946,13 +7798,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "apps/web/node_modules/scheduler": {
-      "version": "0.23.0",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
       }
     },
     "apps/web/node_modules/schema-utils": {
@@ -9638,9 +9483,165 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/konva": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-10.2.0.tgz",
+      "integrity": "sha512-JBoz0Xjbf49UPxCZegZ4WseqOzJ+C4AUDOtJ9eBve5RS5Fcq/u8TdBD5fDl/uPFInpC3a9uycm0sRyZpF4hheg==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/pedal_shootout_front_end": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-konva": {
+      "version": "18.2.14",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-18.2.14.tgz",
+      "integrity": "sha512-lBDe/5fTgquMdg1AHI0B16YZdAOvEhWMBWuo12ioyY0icdxcz9Cf12j86fsCJCHdnvjUOlZeC0f5q+siyHbD4Q==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.2",
+        "its-fine": "^1.1.1",
+        "react-reconciler": "~0.29.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0 || ^10.0.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+      "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Canvas infrastructure**: Install react-konva/konva, add a six-tab view nav (Layout, Audio, Power, MIDI, Control, List) with Audio/MIDI/Control disabled as "coming soon"
- **Layout view**: Free-form draggable product cards with positions persisted in localStorage per workbench
- **Power view**: Interactive power connection mapping with drag-to-connect and click-click-connect, real-time voltage/current/polarity validation (green/yellow/red), acknowledgeable warnings, auto-assign button, and a floating X delete button for touch-friendly connection removal
- **Shared utilities**: Extract `assignPedalsToOutputs()` from `PowerBudgetInsight` into `powerAssignment.ts`; add `validateConnection()` and voltage/polarity helpers to `powerUtils.ts`
- **State management**: Extend `WorkbenchContext` with per-view positions and power connections stored in localStorage
- **Tests**: Add unit tests for `powerUtils` validation functions; add Konva/react-konva mocks for Jest

## Test plan
- [x] `npm run web:build` compiles without errors
- [x] `npm run web:test` passes (18 tests)
- [x] Sub-nav renders all 6 tabs; Audio/MIDI/Control show disabled state
- [x] Layout view: products appear as cards, can be dragged, positions persist across reload
- [x] Power view: supply output ports and pedal power input ports render with port dots
- [x] Power view: connections created via drag or click-click, removed via Delete key or floating X button
- [x] Power view: green/yellow/red validation displays correctly for voltage/current/polarity mismatches
- [x] Power view: yellow warnings can be acknowledged ("I have this adapter")
- [x] Power view: auto-assign button populates connections
- [x] List view: unchanged behavior, sidebar insights still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)