### PR TITLE
Allow multiple instances of the same product on workbench

### DIFF
--- a/apps/web/src/components/Workbench/LayoutView.tsx
+++ b/apps/web/src/components/Workbench/LayoutView.tsx
@@ -28,14 +28,14 @@ const LayoutView = ({ rows }: LayoutViewProps) => {
   const { getViewPositions, updateViewPosition } = useWorkbench();
   const savedPositions = getViewPositions(VIEW_KEY);
 
-  const getPosition = (productId: number, index: number) => {
-    const saved = savedPositions[String(productId)];
+  const getPosition = (instanceId: string, index: number) => {
+    const saved = savedPositions[instanceId];
     if (saved) return saved;
     return defaultPosition(index);
   };
 
-  const handleDragEnd = (productId: number, x: number, y: number) => {
-    updateViewPosition(VIEW_KEY, productId, x, y);
+  const handleDragEnd = (instanceId: string, x: number, y: number) => {
+    updateViewPosition(VIEW_KEY, instanceId, x, y);
   };
 
   if (rows.length === 0) {
@@ -49,16 +49,16 @@ const LayoutView = ({ rows }: LayoutViewProps) => {
   return (
     <CanvasBase>
       {rows.map((row, index) => {
-        const pos = getPosition(row.id, index);
+        const pos = getPosition(row.instanceId, index);
         return (
           <ProductCard
-            key={row.id}
+            key={row.instanceId}
             productType={row.product_type}
             manufacturer={row.manufacturer}
             model={row.model}
             x={pos.x}
             y={pos.y}
-            onDragEnd={(x, y) => handleDragEnd(row.id, x, y)}
+            onDragEnd={(x, y) => handleDragEnd(row.instanceId, x, y)}
           />
         );
       })}

--- a/apps/web/src/components/Workbench/PowerBudgetInsight.tsx
+++ b/apps/web/src/components/Workbench/PowerBudgetInsight.tsx
@@ -98,7 +98,7 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
       const mismatched = consumers.filter(c => c.polarity != null && normalizePolarity(c.polarity) !== majorityPolarity);
       for (const c of mismatched) {
         warnings.push(
-          <div key={`polarity-${c.manufacturer}-${c.model}`} className="power-budget__warning power-budget__warning--warn">
+          <div key={`polarity-${c.instanceId}`} className="power-budget__warning power-budget__warning--warn">
             <strong>Polarity:</strong> {c.manufacturer} {c.model} requires {c.polarity} — you may need a polarity-reversal adapter cable.
           </div>
         );
@@ -111,7 +111,7 @@ const PowerBudgetInsight = ({ rows }: PowerBudgetInsightProps) => {
       const mismatched = consumers.filter(c => c.connector_type != null && normalizeConnector(c.connector_type) !== majorityConnector);
       for (const c of mismatched) {
         warnings.push(
-          <div key={`connector-${c.manufacturer}-${c.model}`} className="power-budget__warning power-budget__warning--warn">
+          <div key={`connector-${c.instanceId}`} className="power-budget__warning power-budget__warning--warn">
             <strong>Connector:</strong> {c.manufacturer} {c.model} uses a {c.connector_type} connector — you may need an adapter cable.
           </div>
         );

--- a/apps/web/src/components/Workbench/index.tsx
+++ b/apps/web/src/components/Workbench/index.tsx
@@ -18,7 +18,7 @@ const Workbench = () => {
     setActiveWorkbench,
   } = useWorkbench();
 
-  const { rows, loading, error } = useWorkbenchProducts();
+  const { rows, groupedRows, loading, error } = useWorkbenchProducts();
 
   const [activeView, setActiveView] = useState<ViewMode>('list');
   const [isRenaming, setIsRenaming] = useState(false);
@@ -80,7 +80,7 @@ const Workbench = () => {
           <>
             <div className="workbench__content">
               <WorkbenchTableView
-                rows={rows}
+                rows={groupedRows}
                 loading={loading}
                 error={error}
                 onRowClick={handleRowClick}

--- a/apps/web/src/components/WorkbenchToggle/index.scss
+++ b/apps/web/src/components/WorkbenchToggle/index.scss
@@ -1,36 +1,69 @@
 .workbench-toggle {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 24px;
+  gap: 0;
   height: 24px;
-  border-radius: 4px;
-  border: 1px solid #333;
-  background: #1a1a1a;
-  color: #666;
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.15s;
-  padding: 0;
-  line-height: 1;
-  font-family: monospace;
 
-  &:hover {
-    border-color: #555;
-    color: #aaa;
-    background: #222;
+  &__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border: 1px solid #333;
+    background: #1a1a1a;
+    color: #666;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s;
+    padding: 0;
+    line-height: 1;
+    font-family: monospace;
+
+    &--add {
+      border-radius: 4px;
+
+      &:hover {
+        border-color: #4a7c59;
+        color: #6abf7b;
+        background: #1a2e1f;
+      }
+    }
+
+    &--remove {
+      border-radius: 4px 0 0 4px;
+      border-right: none;
+
+      &:hover {
+        border-color: #8b4444;
+        color: #cc6060;
+        background: #2e1a1a;
+      }
+    }
   }
 
-  &--active {
-    border-color: #4a7c59;
-    color: #6abf7b;
+  &__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 24px;
+    padding: 0 4px;
+    border: 1px solid #4a7c59;
+    border-left: none;
+    border-right: none;
     background: #1a2e1f;
+    color: #6abf7b;
+    font-size: 11px;
+    font-weight: 600;
+    font-family: monospace;
+    line-height: 1;
+  }
 
-    &:hover {
-      border-color: #8b4444;
-      color: #cc6060;
-      background: #2e1a1a;
-    }
+  // When count is visible, the add button loses its left border-radius
+  &__count + &__btn--add {
+    border-radius: 0 4px 4px 0;
+    border-left: none;
   }
 }

--- a/apps/web/src/components/WorkbenchToggle/index.tsx
+++ b/apps/web/src/components/WorkbenchToggle/index.tsx
@@ -7,27 +7,49 @@ interface WorkbenchToggleProps {
 }
 
 const WorkbenchToggle = ({ productId, productType }: WorkbenchToggleProps) => {
-  const { addItem, removeItem, isInWorkbench } = useWorkbench();
-  const active = isInWorkbench(productId);
+  const { addItem, removeItem, countInWorkbench, activeWorkbench } = useWorkbench();
+  const count = countInWorkbench(productId);
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleAdd = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (active) {
-      removeItem(productId);
-    } else {
-      addItem(productId, productType);
+    addItem(productId, productType);
+  };
+
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    // Remove the most recently added instance of this product
+    const instances = activeWorkbench.items
+      .filter(item => item.productId === productId)
+      .sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+    if (instances.length > 0) {
+      removeItem(instances[0].instanceId);
     }
   };
 
   return (
-    <button
-      className={`workbench-toggle ${active ? 'workbench-toggle--active' : ''}`}
-      onClick={handleClick}
-      title={active ? 'Remove from workbench' : 'Add to workbench'}
-      aria-label={active ? 'Remove from workbench' : 'Add to workbench'}
-    >
-      {active ? '\u2713' : '+'}
-    </button>
+    <span className="workbench-toggle">
+      {count > 0 && (
+        <button
+          className="workbench-toggle__btn workbench-toggle__btn--remove"
+          onClick={handleRemove}
+          title="Remove one from workbench"
+          aria-label="Remove one from workbench"
+        >
+          &minus;
+        </button>
+      )}
+      {count > 0 && (
+        <span className="workbench-toggle__count">{count}</span>
+      )}
+      <button
+        className="workbench-toggle__btn workbench-toggle__btn--add"
+        onClick={handleAdd}
+        title="Add to workbench"
+        aria-label="Add to workbench"
+      >
+        +
+      </button>
+    </span>
   );
 };
 

--- a/apps/web/src/types/power.ts
+++ b/apps/web/src/types/power.ts
@@ -7,6 +7,7 @@ import { Jack } from '../utils/transformers';
 
 export interface PowerConsumer {
   productId: number;
+  instanceId: string;
   manufacturer: string;
   model: string;
   current_ma: number | null;
@@ -17,6 +18,7 @@ export interface PowerConsumer {
 
 export interface PowerSupplyInfo {
   productId: number;
+  instanceId: string;
   manufacturer: string;
   model: string;
   total_current_ma: number | null;
@@ -31,6 +33,7 @@ export interface PowerSupplyInfo {
 export interface TaggedOutputJack extends Jack {
   supplyName: string;
   supplyProductId: number;
+  supplyInstanceId: string;
   portIndex: number;
 }
 

--- a/apps/web/src/utils/powerAssignment.ts
+++ b/apps/web/src/utils/powerAssignment.ts
@@ -29,6 +29,7 @@ export type {
 /** Rows must have this shape — matches WorkbenchRow from WorkbenchTable */
 interface PowerRow {
   id: number;
+  instanceId: string;
   product_type: string;
   manufacturer: string;
   model: string;
@@ -142,6 +143,7 @@ export function assignPedalsToOutputs(
         ...jack,
         supplyName: `${supply.manufacturer} ${supply.model}`,
         supplyProductId: supply.productId,
+        supplyInstanceId: supply.instanceId,
         portIndex: idx + 1,
       });
     });
@@ -242,6 +244,7 @@ export function extractPowerData(rows: PowerRow[]): PowerBudgetData {
     if (row.product_type === 'power_supply') {
       supplies.push({
         productId: row.id,
+        instanceId: row.instanceId,
         manufacturer: row.manufacturer,
         model: row.model,
         total_current_ma: (row.detail.total_current_ma as number) ?? null,
@@ -257,6 +260,7 @@ export function extractPowerData(rows: PowerRow[]): PowerBudgetData {
       if (powerJack || row.jacks.some(j => j.category === 'power' && j.direction === 'input')) {
         consumers.push({
           productId: row.id,
+          instanceId: row.instanceId,
           manufacturer: row.manufacturer,
           model: row.model,
           current_ma: powerJack?.current_ma ?? null,


### PR DESCRIPTION
## Summary
- Adds `instanceId` (UUID) to each workbench item, enabling multiple instances of the same product
- Redesigns the WorkbenchToggle as a +/- button pair with count indicator
- Groups duplicate products into a single row with a Qty column in the list view
- Layout and Power views render one card per instance for physical placement
- Updates PowerView with composite `instanceId:jackId` port keys so duplicate products have independent port positions and connections
- Includes localStorage migration to backfill `instanceId` on existing workbench data

## Files changed (10)
- `context/WorkbenchContext.tsx` — Core: instanceId, new API (removeItem by instanceId, removeAllInstances, countInWorkbench), updated ViewPositions/PowerConnection
- `components/WorkbenchToggle/index.tsx` + `index.scss` — +/- button group with count
- `components/Workbench/WorkbenchTable.tsx` — instanceId/quantity/instanceIds on WorkbenchRow, deduplicated fetch, groupedRows, Qty column
- `components/Workbench/index.tsx` — Routes groupedRows to list view, rows to canvas views
- `components/Workbench/LayoutView.tsx` — Keys/positions by instanceId
- `components/Workbench/PowerView.tsx` — Composite port keys, instance-scoped click handlers
- `components/Workbench/PowerBudgetInsight.tsx` — Unique React keys for duplicate instances
- `types/power.ts` + `utils/powerAssignment.ts` — instanceId on PowerConsumer, PowerSupplyInfo, TaggedOutputJack

## Test plan
- [ ] Build passes (`npm run web:build`)
- [ ] All 18 tests pass (`npm run web:test`)
- [x] Add a product from catalog — count shows "1", minus button appears
- [x] Click "+" again — count shows "2"
- [x] Click "−" — count drops to "1"
- [x] Workbench list view shows one row with "× 2" in Qty column
- [x] Click "×" on grouped row — removes all instances
- [x] Layout view shows separate draggable cards per instance
- [x] Power view shows independent port dots and connections per instance
- [x] Refresh page — localStorage migration preserves existing items

🤖 Generated with [Claude Code](https://claude.com/claude-code)