### PR TITLE
Add proportional card sizing, zoom/pan, and auto-fit

### DIFF
--- a/apps/web/src/components/Workbench/CanvasBase.tsx
+++ b/apps/web/src/components/Workbench/CanvasBase.tsx
@@ -4,16 +4,38 @@ import Konva from 'konva';
 
 interface CanvasBaseProps {
   children: ReactNode;
+  scale?: number;
+  offsetX?: number;
+  offsetY?: number;
   onStageClick?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
   onStageMouseMove?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
   onStageMouseUp?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
+  onWheel?: (e: Konva.KonvaEventObject<WheelEvent>) => void;
+  onTouchMove?: (e: Konva.KonvaEventObject<TouchEvent>) => void;
+  onTouchEnd?: (e: Konva.KonvaEventObject<TouchEvent>) => void;
+  onStageDragEnd?: (e: Konva.KonvaEventObject<DragEvent>) => void;
+  onDimensionsChange?: (width: number, height: number) => void;
 }
 
 /**
  * Shared Konva canvas wrapper that auto-sizes to fill its parent container.
+ * Supports zoom (via scale) and pan (via offset + Stage dragging).
  * Renders a dark background layer and a content layer for children.
  */
-const CanvasBase = ({ children, onStageClick, onStageMouseMove, onStageMouseUp }: CanvasBaseProps) => {
+const CanvasBase = ({
+  children,
+  scale = 1,
+  offsetX = 0,
+  offsetY = 0,
+  onStageClick,
+  onStageMouseMove,
+  onStageMouseUp,
+  onWheel,
+  onTouchMove,
+  onTouchEnd,
+  onStageDragEnd,
+  onDimensionsChange,
+}: CanvasBaseProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
 
@@ -22,10 +44,10 @@ const CanvasBase = ({ children, onStageClick, onStageMouseMove, onStageMouseUp }
     if (!container) return;
 
     const updateSize = () => {
-      setDimensions({
-        width: container.clientWidth,
-        height: container.clientHeight,
-      });
+      const w = container.clientWidth;
+      const h = container.clientHeight;
+      setDimensions({ width: w, height: h });
+      onDimensionsChange?.(w, h);
     };
 
     updateSize();
@@ -33,7 +55,7 @@ const CanvasBase = ({ children, onStageClick, onStageMouseMove, onStageMouseUp }
     const observer = new ResizeObserver(updateSize);
     observer.observe(container);
     return () => observer.disconnect();
-  }, []);
+  }, [onDimensionsChange]);
 
   return (
     <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
@@ -41,16 +63,26 @@ const CanvasBase = ({ children, onStageClick, onStageMouseMove, onStageMouseUp }
       <Stage
         width={dimensions.width}
         height={dimensions.height}
+        scaleX={scale}
+        scaleY={scale}
+        x={offsetX}
+        y={offsetY}
+        draggable
         onClick={onStageClick}
+        onTap={onStageClick}
         onMouseMove={onStageMouseMove}
         onMouseUp={onStageMouseUp}
+        onWheel={onWheel}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        onDragEnd={onStageDragEnd}
       >
         <Layer>
           <Rect
-            x={0}
-            y={0}
-            width={dimensions.width}
-            height={dimensions.height}
+            x={-offsetX / scale}
+            y={-offsetY / scale}
+            width={dimensions.width / scale}
+            height={dimensions.height / scale}
             fill="#111"
           />
         </Layer>
@@ -62,4 +94,5 @@ const CanvasBase = ({ children, onStageClick, onStageMouseMove, onStageMouseUp }
   );
 };
 
-export default CanvasBase;
+export { CanvasBase as default };
+export type { CanvasBaseProps };

--- a/apps/web/src/components/Workbench/LayoutView.tsx
+++ b/apps/web/src/components/Workbench/LayoutView.tsx
@@ -1,23 +1,66 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useWorkbench } from '../../context/WorkbenchContext';
 import { WorkbenchRow } from './WorkbenchTable';
+import { useCanvasViewport } from '../../hooks/useCanvasViewport';
+import { calculateBoundingBox } from '../../utils/canvasUtils';
 import CanvasBase from './CanvasBase';
-import ProductCard from './ProductCard';
+import ProductCard, { CARD_WIDTH, CARD_HEIGHT } from './ProductCard';
+import ZoomControls from './ZoomControls';
 
 const VIEW_KEY = 'layout';
-const GRID_COLUMNS = 4;
-const CARD_SPACING_X = 160;
-const CARD_SPACING_Y = 84;
-const GRID_OFFSET_X = 20;
-const GRID_OFFSET_Y = 20;
 
-/** Assign a default grid position for products without a saved position */
-function defaultPosition(index: number): { x: number; y: number } {
-  const col = index % GRID_COLUMNS;
-  const row = Math.floor(index / GRID_COLUMNS);
-  return {
-    x: GRID_OFFSET_X + col * CARD_SPACING_X,
-    y: GRID_OFFSET_Y + row * CARD_SPACING_Y,
-  };
+/** 1mm = 1 world pixel. Cards are sized proportionally to real dimensions. */
+const MM_TO_PX = 1.0;
+const MIN_CARD_WIDTH = 100;
+const MIN_CARD_HEIGHT = 50;
+const DEFAULT_CARD_WIDTH = CARD_WIDTH;   // 140
+const DEFAULT_CARD_HEIGHT = CARD_HEIGHT; // 64
+
+/** Flow layout constants for default positions */
+const FLOW_MAX_WIDTH = 800;
+const FLOW_GAP = 20;
+const FLOW_OFFSET_X = 20;
+const FLOW_OFFSET_Y = 20;
+
+/** Compute card dimensions from product's real-world size (top-down view). */
+function cardDimensions(row: WorkbenchRow): { width: number; height: number } {
+  if (row.width_mm != null && row.depth_mm != null) {
+    return {
+      width: Math.max(row.width_mm * MM_TO_PX, MIN_CARD_WIDTH),
+      height: Math.max(row.depth_mm * MM_TO_PX, MIN_CARD_HEIGHT),
+    };
+  }
+  return { width: DEFAULT_CARD_WIDTH, height: DEFAULT_CARD_HEIGHT };
+}
+
+/**
+ * Compute default flow-layout positions for cards with variable sizes.
+ * Wraps to a new row when cumulative width exceeds FLOW_MAX_WIDTH.
+ */
+function computeFlowPositions(
+  rows: WorkbenchRow[],
+): Map<string, { x: number; y: number }> {
+  const map = new Map<string, { x: number; y: number }>();
+  let cursorX = FLOW_OFFSET_X;
+  let cursorY = FLOW_OFFSET_Y;
+  let rowHeight = 0;
+
+  for (const row of rows) {
+    const dims = cardDimensions(row);
+
+    // Wrap to next row if this card exceeds the max width
+    if (cursorX + dims.width > FLOW_MAX_WIDTH + FLOW_OFFSET_X && cursorX > FLOW_OFFSET_X) {
+      cursorX = FLOW_OFFSET_X;
+      cursorY += rowHeight + FLOW_GAP;
+      rowHeight = 0;
+    }
+
+    map.set(row.instanceId, { x: cursorX, y: cursorY });
+    cursorX += dims.width + FLOW_GAP;
+    rowHeight = Math.max(rowHeight, dims.height);
+  }
+
+  return map;
 }
 
 interface LayoutViewProps {
@@ -28,15 +71,56 @@ const LayoutView = ({ rows }: LayoutViewProps) => {
   const { getViewPositions, updateViewPosition } = useWorkbench();
   const savedPositions = getViewPositions(VIEW_KEY);
 
-  const getPosition = (instanceId: string, index: number) => {
+  const viewport = useCanvasViewport(VIEW_KEY);
+  const [stageDims, setStageDims] = useState({ width: 800, height: 600 });
+  const hasAutoFit = useRef(false);
+
+  const handleDimensionsChange = useCallback((width: number, height: number) => {
+    setStageDims({ width, height });
+  }, []);
+
+  // Compute flow-layout default positions for cards without saved positions
+  const flowDefaults = computeFlowPositions(rows);
+
+  const getPosition = (instanceId: string) => {
     const saved = savedPositions[instanceId];
     if (saved) return saved;
-    return defaultPosition(index);
+    return flowDefaults.get(instanceId) || { x: FLOW_OFFSET_X, y: FLOW_OFFSET_Y };
   };
 
   const handleDragEnd = (instanceId: string, x: number, y: number) => {
     updateViewPosition(VIEW_KEY, instanceId, x, y);
   };
+
+  // Auto-fit on first render when no saved viewport exists
+  useEffect(() => {
+    if (hasAutoFit.current || rows.length === 0) return;
+    // Only auto-fit if the viewport is at default (no saved state)
+    const saved = viewport.scale === 1 && viewport.offsetX === 0 && viewport.offsetY === 0;
+    if (!saved) { hasAutoFit.current = true; return; }
+
+    const cards = rows.map(row => {
+      const pos = getPosition(row.instanceId);
+      const dims = cardDimensions(row);
+      return { x: pos.x, y: pos.y, width: dims.width, height: dims.height };
+    });
+
+    const bbox = calculateBoundingBox(cards);
+    viewport.fitAll(bbox, stageDims.width, stageDims.height);
+    hasAutoFit.current = true;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows.length, stageDims.width, stageDims.height]);
+
+  const handleFitAll = useCallback(() => {
+    const cards = rows.map(row => {
+      const pos = getPosition(row.instanceId);
+      const dims = cardDimensions(row);
+      return { x: pos.x, y: pos.y, width: dims.width, height: dims.height };
+    });
+    const bbox = calculateBoundingBox(cards);
+    viewport.fitAll(bbox, stageDims.width, stageDims.height);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows, savedPositions, stageDims, viewport.fitAll]);
 
   if (rows.length === 0) {
     return (
@@ -47,22 +131,43 @@ const LayoutView = ({ rows }: LayoutViewProps) => {
   }
 
   return (
-    <CanvasBase>
-      {rows.map((row, index) => {
-        const pos = getPosition(row.instanceId, index);
-        return (
-          <ProductCard
-            key={row.instanceId}
-            productType={row.product_type}
-            manufacturer={row.manufacturer}
-            model={row.model}
-            x={pos.x}
-            y={pos.y}
-            onDragEnd={(x, y) => handleDragEnd(row.instanceId, x, y)}
-          />
-        );
-      })}
-    </CanvasBase>
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <CanvasBase
+        scale={viewport.scale}
+        offsetX={viewport.offsetX}
+        offsetY={viewport.offsetY}
+        onWheel={viewport.handleWheel}
+        onTouchMove={viewport.handleTouchMove}
+        onTouchEnd={viewport.handleTouchEnd}
+        onStageDragEnd={viewport.handleStageDragEnd}
+        onDimensionsChange={handleDimensionsChange}
+      >
+        {rows.map((row) => {
+          const pos = getPosition(row.instanceId);
+          const dims = cardDimensions(row);
+          return (
+            <ProductCard
+              key={row.instanceId}
+              productType={row.product_type}
+              manufacturer={row.manufacturer}
+              model={row.model}
+              x={pos.x}
+              y={pos.y}
+              cardWidth={dims.width}
+              cardHeight={dims.height}
+              onDragEnd={(x, y) => handleDragEnd(row.instanceId, x, y)}
+            />
+          );
+        })}
+      </CanvasBase>
+
+      <ZoomControls
+        scale={viewport.scale}
+        onZoomIn={() => viewport.zoomIn(stageDims.width, stageDims.height)}
+        onZoomOut={() => viewport.zoomOut(stageDims.width, stageDims.height)}
+        onFitAll={handleFitAll}
+      />
+    </div>
   );
 };
 

--- a/apps/web/src/components/Workbench/PowerView.tsx
+++ b/apps/web/src/components/Workbench/PowerView.tsx
@@ -9,10 +9,13 @@ import {
 } from '../../utils/powerAssignment';
 import { validateConnection, ConnectionValidation } from '../../utils/powerUtils';
 import { Jack } from '../../utils/transformers';
+import { useCanvasViewport } from '../../hooks/useCanvasViewport';
+import { calculateBoundingBox } from '../../utils/canvasUtils';
 import CanvasBase from './CanvasBase';
 import ProductCard, { CARD_WIDTH, CARD_HEIGHT } from './ProductCard';
 import PortDot from './PortDot';
 import ConnectionLine from './ConnectionLine';
+import ZoomControls from './ZoomControls';
 import Konva from 'konva';
 
 const VIEW_KEY = 'power';
@@ -61,6 +64,14 @@ const PowerView = ({ rows }: PowerViewProps) => {
   const savedPositions = getViewPositions(VIEW_KEY);
   const powerData = extractPowerData(rows);
   const connections = activeWorkbench.powerConnections ?? [];
+
+  // Zoom/pan
+  const viewport = useCanvasViewport(VIEW_KEY);
+  const [stageDims, setStageDims] = useState({ width: 800, height: 600 });
+
+  const handleDimensionsChange = useCallback((width: number, height: number) => {
+    setStageDims({ width, height });
+  }, []);
 
   // Interaction state
   const [pendingSource, setPendingSource] = useState<PendingConnection | null>(null);
@@ -121,6 +132,7 @@ const PowerView = ({ rows }: PowerViewProps) => {
   }, [savedPositions]);
 
   // Port absolute position lookup — keyed by composite key (instanceId:jackId)
+  // These are WORLD coordinates
   const portPositions = useMemo(() => {
     const map = new Map<string, { x: number; y: number }>();
 
@@ -147,7 +159,6 @@ const PowerView = ({ rows }: PowerViewProps) => {
   }, [supplyEntries, consumerEntries, getPosition]);
 
   // Compute total current on each output port (for daisy-chain validation)
-  // Keyed by composite key (instanceId:jackId)
   const currentByOutput = useMemo(() => {
     const map = new Map<string, number>();
     for (const conn of connections) {
@@ -173,7 +184,7 @@ const PowerView = ({ rows }: PowerViewProps) => {
           currentByOutput.get(key),
         ));
       } else {
-        map.set(conn.id, { status: 'valid', warnings: [] });
+        map.set(conn.id, { status: 'valid' as const, warnings: [] });
       }
     }
     return map;
@@ -185,7 +196,6 @@ const PowerView = ({ rows }: PowerViewProps) => {
 
   // --- Connection interaction ---
 
-  /** Creates a port click handler scoped to a specific instance */
   const makePortClickHandler = useCallback((instanceId: string) => (jackId: number) => {
     const jack = jackMap.get(jackId);
     if (!jack) return;
@@ -194,19 +204,15 @@ const PowerView = ({ rows }: PowerViewProps) => {
     const key = portKey(instanceId, jackId);
 
     if (!pendingSource) {
-      // First click — start pending connection
       setPendingSource({ jackId, instanceId, compositeKey: key, direction });
       setMousePos(null);
       setSelectedConnectionId(null);
       setWarningPopover(null);
     } else if (pendingSource.compositeKey === key) {
-      // Clicked same port — cancel
       setPendingSource(null);
       setMousePos(null);
     } else {
-      // Second click — attempt connection
       if (pendingSource.direction === direction) {
-        // Can't connect output→output or input→input
         setPendingSource(null);
         setMousePos(null);
         return;
@@ -228,18 +234,20 @@ const PowerView = ({ rows }: PowerViewProps) => {
     }
   }, [pendingSource, jackMap, addPowerConnection]);
 
-  // Track mouse position for preview line (only while a connection is pending)
+  // Track mouse position for preview line — convert screen coords to world coords
   const handleStageMouseMove = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
     if (!pendingSource) return;
     const stage = e.target.getStage();
     if (stage) {
       const pos = stage.getPointerPosition();
-      if (pos) setMousePos({ x: pos.x, y: pos.y });
+      if (pos) {
+        const world = viewport.screenToWorld(pos.x, pos.y);
+        setMousePos(world);
+      }
     }
-  }, [pendingSource]);
+  }, [pendingSource, viewport.screenToWorld]);
 
   const handleStageClick = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
-    // Click on empty canvas — deselect and cancel pending
     if (e.target === e.target.getStage()) {
       setPendingSource(null);
       setSelectedConnectionId(null);
@@ -252,7 +260,6 @@ const PowerView = ({ rows }: PowerViewProps) => {
     const conn = connections.find(c => c.id === connId);
 
     if (validation && validation.warnings.length > 0 && conn) {
-      // Show warning popover
       const sourcePos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
       const targetPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
       if (sourcePos && targetPos) {
@@ -282,7 +289,6 @@ const PowerView = ({ rows }: PowerViewProps) => {
     }
   }, [selectedConnectionId, removePowerConnection]);
 
-  // Register keyboard listener
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
@@ -296,7 +302,6 @@ const PowerView = ({ rows }: PowerViewProps) => {
 
     const result = assignPedalsToOutputs(powerData.consumers, powerData.supplies);
     const newConnections: PowerConnection[] = result.assignments.map((a) => {
-      // Find the consumer's power input jack
       const consumerRow = rowMap.get(a.consumer.instanceId);
       const inputJack = consumerRow ? getPowerInputJack(consumerRow) : undefined;
 
@@ -314,6 +319,21 @@ const PowerView = ({ rows }: PowerViewProps) => {
     setWarningPopover(null);
   }, [connections, powerData, rowMap, setPowerConnections]);
 
+  // Fit-all handler
+  const handleFitAll = useCallback(() => {
+    const cards: Array<{ x: number; y: number; width: number; height: number }> = [];
+    for (const entry of supplyEntries) {
+      const pos = getPosition(entry.instanceId, entry.x, entry.y);
+      cards.push({ x: pos.x, y: pos.y, width: CARD_WIDTH, height: supplyCardHeight(entry.outputJacks.length) });
+    }
+    for (const entry of consumerEntries) {
+      const pos = getPosition(entry.instanceId, entry.x, entry.y);
+      cards.push({ x: pos.x, y: pos.y, width: CARD_WIDTH, height: CARD_HEIGHT });
+    }
+    const bbox = calculateBoundingBox(cards);
+    viewport.fitAll(bbox, stageDims.width, stageDims.height);
+  }, [supplyEntries, consumerEntries, getPosition, viewport, stageDims]);
+
   if (rows.length === 0) {
     return (
       <div className="workbench__canvas-placeholder">
@@ -330,14 +350,22 @@ const PowerView = ({ rows }: PowerViewProps) => {
     );
   }
 
-  // Pending source port position for preview line
+  // Pending source port position for preview line (world coords)
   const pendingSourcePos = pendingSource ? portPositions.get(pendingSource.compositeKey) : null;
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
       <CanvasBase
+        scale={viewport.scale}
+        offsetX={viewport.offsetX}
+        offsetY={viewport.offsetY}
+        onWheel={viewport.handleWheel}
+        onTouchMove={viewport.handleTouchMove}
+        onTouchEnd={viewport.handleTouchEnd}
+        onStageDragEnd={viewport.handleStageDragEnd}
         onStageClick={handleStageClick}
         onStageMouseMove={handleStageMouseMove}
+        onDimensionsChange={handleDimensionsChange}
       >
         {/* Connection lines */}
         {connections.map((conn) => {
@@ -364,7 +392,7 @@ const PowerView = ({ rows }: PowerViewProps) => {
           );
         })}
 
-        {/* Preview line while creating connection */}
+        {/* Preview line while creating connection (both in world coords now) */}
         {pendingSource && pendingSourcePos && mousePos && (
           <ConnectionLine
             sourceX={pendingSourcePos.x}
@@ -483,20 +511,30 @@ const PowerView = ({ rows }: PowerViewProps) => {
         )}
       </div>
 
-      {/* Floating delete button for selected connection */}
+      {/* Zoom controls */}
+      <ZoomControls
+        scale={viewport.scale}
+        onZoomIn={() => viewport.zoomIn(stageDims.width, stageDims.height)}
+        onZoomOut={() => viewport.zoomOut(stageDims.width, stageDims.height)}
+        onFitAll={handleFitAll}
+      />
+
+      {/* Floating delete button for selected connection — convert world to screen coords */}
       {selectedConnectionId && (() => {
         const conn = connections.find(c => c.id === selectedConnectionId);
         if (!conn) return null;
         const srcPos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
         const tgtPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
         if (!srcPos || !tgtPos) return null;
+        const midWorld = { x: (srcPos.x + tgtPos.x) / 2, y: (srcPos.y + tgtPos.y) / 2 };
+        const midScreen = viewport.worldToScreen(midWorld.x, midWorld.y);
         return (
           <button
             className="workbench__power-delete-btn"
             style={{
               position: 'absolute',
-              left: (srcPos.x + tgtPos.x) / 2,
-              top: (srcPos.y + tgtPos.y) / 2,
+              left: midScreen.x,
+              top: midScreen.y,
             }}
             title="Delete connection"
             onClick={() => {
@@ -510,40 +548,43 @@ const PowerView = ({ rows }: PowerViewProps) => {
         );
       })()}
 
-      {/* Warning popover */}
-      {warningPopover && (
-        <div
-          className="workbench__power-popover"
-          style={{
-            position: 'absolute',
-            left: warningPopover.x,
-            top: warningPopover.y,
-          }}
-        >
-          <div className="workbench__power-popover-warnings">
-            {warningPopover.warnings.map((w, i) => (
-              <div key={i} className="workbench__power-popover-warning">{w}</div>
-            ))}
-          </div>
-          <button
-            className="workbench__power-popover-btn"
-            onClick={() => {
-              for (const w of warningPopover.warnings) {
-                acknowledgeWarning(warningPopover.connId, w);
-              }
-              setWarningPopover(null);
+      {/* Warning popover — convert world to screen coords */}
+      {warningPopover && (() => {
+        const screenPos = viewport.worldToScreen(warningPopover.x, warningPopover.y);
+        return (
+          <div
+            className="workbench__power-popover"
+            style={{
+              position: 'absolute',
+              left: screenPos.x,
+              top: screenPos.y,
             }}
           >
-            I have this adapter
-          </button>
-          <button
-            className="workbench__power-popover-btn workbench__power-popover-btn--close"
-            onClick={() => setWarningPopover(null)}
-          >
-            Close
-          </button>
-        </div>
-      )}
+            <div className="workbench__power-popover-warnings">
+              {warningPopover.warnings.map((w, i) => (
+                <div key={i} className="workbench__power-popover-warning">{w}</div>
+              ))}
+            </div>
+            <button
+              className="workbench__power-popover-btn"
+              onClick={() => {
+                for (const w of warningPopover.warnings) {
+                  acknowledgeWarning(warningPopover.connId, w);
+                }
+                setWarningPopover(null);
+              }}
+            >
+              I have this adapter
+            </button>
+            <button
+              className="workbench__power-popover-btn workbench__power-popover-btn--close"
+              onClick={() => setWarningPopover(null)}
+            >
+              Close
+            </button>
+          </div>
+        );
+      })()}
     </div>
   );
 };

--- a/apps/web/src/components/Workbench/ProductCard.tsx
+++ b/apps/web/src/components/Workbench/ProductCard.tsx
@@ -25,6 +25,8 @@ interface ProductCardProps {
   onClick?: () => void;
   selected?: boolean;
   children?: ReactNode;
+  /** Override card width (e.g., proportional sizing in Layout view) */
+  cardWidth?: number;
   /** Override card height (e.g., taller for supply cards with many ports) */
   cardHeight?: number;
 }
@@ -43,9 +45,11 @@ const ProductCard = ({
   onClick,
   selected = false,
   children,
+  cardWidth,
   cardHeight,
 }: ProductCardProps) => {
   const colors = TYPE_COLORS[productType] || TYPE_COLORS.pedal;
+  const width = cardWidth ?? CARD_WIDTH;
   const height = cardHeight ?? CARD_HEIGHT;
 
   return (
@@ -61,7 +65,7 @@ const ProductCard = ({
     >
       {/* Card background */}
       <Rect
-        width={CARD_WIDTH}
+        width={width}
         height={height}
         fill={colors.fill}
         stroke={selected ? '#e0e0e0' : colors.stroke}
@@ -75,7 +79,7 @@ const ProductCard = ({
       <Text
         x={8}
         y={8}
-        width={CARD_WIDTH - 16}
+        width={width - 16}
         text={manufacturer}
         fontSize={11}
         fontFamily="'Helvetica Neue', sans-serif"
@@ -88,7 +92,7 @@ const ProductCard = ({
       <Text
         x={8}
         y={24}
-        width={CARD_WIDTH - 16}
+        width={width - 16}
         text={model}
         fontSize={11}
         fontFamily="'SF Mono', 'Fira Code', monospace"
@@ -96,17 +100,19 @@ const ProductCard = ({
         ellipsis
         wrap="none"
       />
-      {/* Type label */}
-      <Text
-        x={8}
-        y={44}
-        width={CARD_WIDTH - 16}
-        text={productType.replace(/_/g, ' ')}
-        fontSize={9}
-        fontFamily="monospace"
-        fill="#555"
-        textTransform="uppercase"
-      />
+      {/* Type label — hide if card is too short */}
+      {height >= 55 && (
+        <Text
+          x={8}
+          y={44}
+          width={width - 16}
+          text={productType.replace(/_/g, ' ')}
+          fontSize={9}
+          fontFamily="monospace"
+          fill="#555"
+          textTransform="uppercase"
+        />
+      )}
       {children}
     </Group>
   );

--- a/apps/web/src/components/Workbench/ZoomControls.tsx
+++ b/apps/web/src/components/Workbench/ZoomControls.tsx
@@ -1,0 +1,47 @@
+/**
+ * Floating zoom controls for canvas views.
+ * Shows +/- zoom buttons, a "Fit" button, and current zoom percentage.
+ */
+
+interface ZoomControlsProps {
+  scale: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  onFitAll: () => void;
+}
+
+const ZoomControls = ({ scale, onZoomIn, onZoomOut, onFitAll }: ZoomControlsProps) => {
+  const pct = Math.round(scale * 100);
+
+  return (
+    <div className="zoom-controls">
+      <button
+        className="zoom-controls__btn"
+        onClick={onZoomOut}
+        title="Zoom out"
+        aria-label="Zoom out"
+      >
+        &minus;
+      </button>
+      <span className="zoom-controls__pct">{pct}%</span>
+      <button
+        className="zoom-controls__btn"
+        onClick={onZoomIn}
+        title="Zoom in"
+        aria-label="Zoom in"
+      >
+        +
+      </button>
+      <button
+        className="zoom-controls__btn zoom-controls__btn--fit"
+        onClick={onFitAll}
+        title="Fit all cards in view"
+        aria-label="Fit all"
+      >
+        Fit
+      </button>
+    </div>
+  );
+};
+
+export default ZoomControls;

--- a/apps/web/src/components/Workbench/index.scss
+++ b/apps/web/src/components/Workbench/index.scss
@@ -416,6 +416,61 @@
   }
 }
 
+// Zoom controls — floating in bottom-right of canvas
+.zoom-controls {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  z-index: 10;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 5px;
+  overflow: hidden;
+
+  &__btn {
+    padding: 6px 12px;
+    border: none;
+    border-right: 1px solid #333;
+    background: transparent;
+    color: #999;
+    font-size: 14px;
+    font-family: monospace;
+    cursor: pointer;
+    transition: all 0.15s;
+    line-height: 1;
+
+    &:hover {
+      color: #ccc;
+      background: #222;
+    }
+
+    &:last-child {
+      border-right: none;
+    }
+
+    &--fit {
+      font-size: 11px;
+      font-weight: 600;
+      padding: 6px 10px;
+    }
+  }
+
+  &__pct {
+    padding: 0 8px;
+    font-size: 11px;
+    font-weight: 600;
+    font-family: monospace;
+    color: #888;
+    min-width: 40px;
+    text-align: center;
+    border-right: 1px solid #333;
+    line-height: 1;
+  }
+}
+
 // Type badges for product type column
 .type-badge {
   display: inline-block;

--- a/apps/web/src/context/WorkbenchContext.tsx
+++ b/apps/web/src/context/WorkbenchContext.tsx
@@ -31,6 +31,11 @@ export interface PowerConnection {
   acknowledgedWarnings?: string[];
 }
 
+/** Per-view zoom/pan state. Keyed by view mode (e.g., 'layout', 'power'). */
+export interface ViewportStates {
+  [viewKey: string]: { scale: number; offsetX: number; offsetY: number };
+}
+
 export interface Workbench {
   id: string;
   name: string;
@@ -42,6 +47,7 @@ export interface Workbench {
   // Canvas view data:
   viewPositions?: ViewPositions;
   powerConnections?: PowerConnection[];
+  viewportStates?: ViewportStates;
 }
 
 interface WorkbenchStore {
@@ -68,6 +74,10 @@ interface WorkbenchContextType {
   // Canvas view positions
   updateViewPosition: (view: string, instanceId: string, x: number, y: number) => void;
   getViewPositions: (view: string) => Record<string, { x: number; y: number }>;
+
+  // Canvas viewport state (zoom/pan)
+  getViewportState: (view: string) => { scale: number; offsetX: number; offsetY: number };
+  updateViewportState: (view: string, state: { scale: number; offsetX: number; offsetY: number }) => void;
 
   // Power connections
   addPowerConnection: (conn: Omit<PowerConnection, 'id'>) => void;
@@ -280,6 +290,23 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     [activeWorkbench],
   );
 
+  // --- Canvas viewport state (zoom/pan) ---
+
+  const getViewportState = useCallback(
+    (view: string): { scale: number; offsetX: number; offsetY: number } => {
+      return activeWorkbench.viewportStates?.[view] || { scale: 1, offsetX: 0, offsetY: 0 };
+    },
+    [activeWorkbench],
+  );
+
+  const updateViewportState = useCallback((view: string, state: { scale: number; offsetX: number; offsetY: number }) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => {
+      const states = { ...(wb.viewportStates || {}) };
+      states[view] = state;
+      return { ...wb, viewportStates: states, updatedAt: new Date().toISOString() };
+    }));
+  }, [updateStore]);
+
   // --- Power connections ---
 
   const addPowerConnection = useCallback((conn: Omit<PowerConnection, 'id'>) => {
@@ -338,13 +365,15 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
       clear,
       updateViewPosition,
       getViewPositions,
+      getViewportState,
+      updateViewportState,
       addPowerConnection,
       removePowerConnection,
       setPowerConnections,
       acknowledgeWarning,
       totalItemCount,
     }),
-    [store.workbenches, activeWorkbench, createWorkbench, renameWorkbench, deleteWorkbench, setActiveWorkbench, addItem, removeItem, removeAllInstances, countInWorkbench, clear, updateViewPosition, getViewPositions, addPowerConnection, removePowerConnection, setPowerConnections, acknowledgeWarning, totalItemCount],
+    [store.workbenches, activeWorkbench, createWorkbench, renameWorkbench, deleteWorkbench, setActiveWorkbench, addItem, removeItem, removeAllInstances, countInWorkbench, clear, updateViewPosition, getViewPositions, getViewportState, updateViewportState, addPowerConnection, removePowerConnection, setPowerConnections, acknowledgeWarning, totalItemCount],
   );
 
   return (

--- a/apps/web/src/hooks/useCanvasViewport.ts
+++ b/apps/web/src/hooks/useCanvasViewport.ts
@@ -1,0 +1,217 @@
+/**
+ * Hook for managing canvas zoom/pan state.
+ *
+ * Provides wheel-to-zoom, pinch-to-zoom, pan-via-drag, fit-all, and
+ * coordinate conversion between screen and world space.
+ *
+ * Viewport state is persisted to WorkbenchContext (and thus localStorage)
+ * with a debounce to avoid excessive writes during continuous zoom.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import Konva from 'konva';
+import { useWorkbench } from '../context/WorkbenchContext';
+import { BoundingBox, calculateFitViewport } from '../utils/canvasUtils';
+
+const MIN_SCALE = 0.15;
+const MAX_SCALE = 4.0;
+const ZOOM_FACTOR = 1.1;
+const STEP_ZOOM_FACTOR = 1.25;
+const SAVE_DEBOUNCE_MS = 200;
+
+export interface CanvasViewport {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  handleWheel: (e: Konva.KonvaEventObject<WheelEvent>) => void;
+  handleTouchMove: (e: Konva.KonvaEventObject<TouchEvent>) => void;
+  handleTouchEnd: () => void;
+  handleStageDragEnd: (e: Konva.KonvaEventObject<DragEvent>) => void;
+  screenToWorld: (screenX: number, screenY: number) => { x: number; y: number };
+  worldToScreen: (worldX: number, worldY: number) => { x: number; y: number };
+  fitAll: (bbox: BoundingBox, stageWidth: number, stageHeight: number) => void;
+  zoomIn: (stageWidth: number, stageHeight: number) => void;
+  zoomOut: (stageWidth: number, stageHeight: number) => void;
+}
+
+function clampScale(s: number): number {
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, s));
+}
+
+export function useCanvasViewport(viewKey: string): CanvasViewport {
+  const { getViewportState, updateViewportState } = useWorkbench();
+
+  const saved = getViewportState(viewKey);
+  const [scale, setScale] = useState(saved.scale);
+  const [offsetX, setOffsetX] = useState(saved.offsetX);
+  const [offsetY, setOffsetY] = useState(saved.offsetY);
+
+  // Track pinch distance for touch zoom
+  const lastPinchDist = useRef<number | null>(null);
+  const lastPinchCenter = useRef<{ x: number; y: number } | null>(null);
+
+  // Debounced save to context
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestState = useRef({ scale, offsetX, offsetY });
+  latestState.current = { scale, offsetX, offsetY };
+
+  const scheduleSave = useCallback(() => {
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      updateViewportState(viewKey, latestState.current);
+    }, SAVE_DEBOUNCE_MS);
+  }, [viewKey, updateViewportState]);
+
+  // Save immediately on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      updateViewportState(viewKey, latestState.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const applyZoom = useCallback((
+    newScale: number,
+    centerX: number,
+    centerY: number,
+    currentScale: number,
+    currentOffsetX: number,
+    currentOffsetY: number,
+  ) => {
+    const clamped = clampScale(newScale);
+    // Keep the point under the cursor fixed in world space
+    const worldX = (centerX - currentOffsetX) / currentScale;
+    const worldY = (centerY - currentOffsetY) / currentScale;
+    const newOffsetX = centerX - worldX * clamped;
+    const newOffsetY = centerY - worldY * clamped;
+    setScale(clamped);
+    setOffsetX(newOffsetX);
+    setOffsetY(newOffsetY);
+    return { scale: clamped, offsetX: newOffsetX, offsetY: newOffsetY };
+  }, []);
+
+  const handleWheel = useCallback((e: Konva.KonvaEventObject<WheelEvent>) => {
+    e.evt.preventDefault();
+    const stage = e.target.getStage();
+    if (!stage) return;
+    const pointer = stage.getPointerPosition();
+    if (!pointer) return;
+
+    const direction = e.evt.deltaY > 0 ? -1 : 1;
+    const newScale = latestState.current.scale * (direction > 0 ? ZOOM_FACTOR : 1 / ZOOM_FACTOR);
+    applyZoom(
+      newScale,
+      pointer.x,
+      pointer.y,
+      latestState.current.scale,
+      latestState.current.offsetX,
+      latestState.current.offsetY,
+    );
+    scheduleSave();
+  }, [applyZoom, scheduleSave]);
+
+  const handleTouchMove = useCallback((e: Konva.KonvaEventObject<TouchEvent>) => {
+    const touches = e.evt.touches;
+    if (touches.length !== 2) return;
+    e.evt.preventDefault();
+
+    const t0 = touches[0];
+    const t1 = touches[1];
+    const dist = Math.sqrt((t1.clientX - t0.clientX) ** 2 + (t1.clientY - t0.clientY) ** 2);
+    const centerX = (t0.clientX + t1.clientX) / 2;
+    const centerY = (t0.clientY + t1.clientY) / 2;
+
+    if (lastPinchDist.current != null && lastPinchCenter.current != null) {
+      const delta = dist / lastPinchDist.current;
+      const newScale = latestState.current.scale * delta;
+      applyZoom(
+        newScale,
+        lastPinchCenter.current.x,
+        lastPinchCenter.current.y,
+        latestState.current.scale,
+        latestState.current.offsetX,
+        latestState.current.offsetY,
+      );
+      scheduleSave();
+    }
+
+    lastPinchDist.current = dist;
+    lastPinchCenter.current = { x: centerX, y: centerY };
+  }, [applyZoom, scheduleSave]);
+
+  const handleTouchEnd = useCallback(() => {
+    lastPinchDist.current = null;
+    lastPinchCenter.current = null;
+  }, []);
+
+  const handleStageDragEnd = useCallback((e: Konva.KonvaEventObject<DragEvent>) => {
+    // Only handle Stage drag, not child Group drags
+    const target = e.target;
+    if (target !== target.getStage()) return;
+    setOffsetX(target.x());
+    setOffsetY(target.y());
+    scheduleSave();
+  }, [scheduleSave]);
+
+  const screenToWorld = useCallback((screenX: number, screenY: number) => ({
+    x: (screenX - latestState.current.offsetX) / latestState.current.scale,
+    y: (screenY - latestState.current.offsetY) / latestState.current.scale,
+  }), []);
+
+  const worldToScreen = useCallback((worldX: number, worldY: number) => ({
+    x: worldX * latestState.current.scale + latestState.current.offsetX,
+    y: worldY * latestState.current.scale + latestState.current.offsetY,
+  }), []);
+
+  const fitAll = useCallback((bbox: BoundingBox, stageWidth: number, stageHeight: number) => {
+    const vp = calculateFitViewport(bbox, stageWidth, stageHeight);
+    setScale(vp.scale);
+    setOffsetX(vp.offsetX);
+    setOffsetY(vp.offsetY);
+    updateViewportState(viewKey, vp);
+  }, [viewKey, updateViewportState]);
+
+  const zoomIn = useCallback((stageWidth: number, stageHeight: number) => {
+    const centerX = stageWidth / 2;
+    const centerY = stageHeight / 2;
+    applyZoom(
+      latestState.current.scale * STEP_ZOOM_FACTOR,
+      centerX,
+      centerY,
+      latestState.current.scale,
+      latestState.current.offsetX,
+      latestState.current.offsetY,
+    );
+    scheduleSave();
+  }, [applyZoom, scheduleSave]);
+
+  const zoomOut = useCallback((stageWidth: number, stageHeight: number) => {
+    const centerX = stageWidth / 2;
+    const centerY = stageHeight / 2;
+    applyZoom(
+      latestState.current.scale / STEP_ZOOM_FACTOR,
+      centerX,
+      centerY,
+      latestState.current.scale,
+      latestState.current.offsetX,
+      latestState.current.offsetY,
+    );
+    scheduleSave();
+  }, [applyZoom, scheduleSave]);
+
+  return {
+    scale,
+    offsetX,
+    offsetY,
+    handleWheel,
+    handleTouchMove,
+    handleTouchEnd,
+    handleStageDragEnd,
+    screenToWorld,
+    worldToScreen,
+    fitAll,
+    zoomIn,
+    zoomOut,
+  };
+}

--- a/apps/web/src/utils/canvasUtils.ts
+++ b/apps/web/src/utils/canvasUtils.ts
@@ -1,0 +1,74 @@
+/**
+ * Canvas viewport utility functions for bounding box and fit-to-view calculations.
+ */
+
+export interface BoundingBox {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+export interface ViewportState {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+/**
+ * Compute the axis-aligned bounding box around a set of positioned cards.
+ */
+export function calculateBoundingBox(
+  cards: Array<{ x: number; y: number; width: number; height: number }>,
+): BoundingBox {
+  if (cards.length === 0) {
+    return { minX: 0, minY: 0, maxX: 0, maxY: 0 };
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const card of cards) {
+    minX = Math.min(minX, card.x);
+    minY = Math.min(minY, card.y);
+    maxX = Math.max(maxX, card.x + card.width);
+    maxY = Math.max(maxY, card.y + card.height);
+  }
+
+  return { minX, minY, maxX, maxY };
+}
+
+/**
+ * Compute the scale and offset needed to fit a bounding box within the stage,
+ * centered with padding.
+ */
+export function calculateFitViewport(
+  bbox: BoundingBox,
+  stageWidth: number,
+  stageHeight: number,
+  padding = 40,
+  minScale = 0.15,
+  maxScale = 2.0,
+): ViewportState {
+  const contentWidth = bbox.maxX - bbox.minX;
+  const contentHeight = bbox.maxY - bbox.minY;
+
+  if (contentWidth <= 0 || contentHeight <= 0) {
+    return { scale: 1, offsetX: 0, offsetY: 0 };
+  }
+
+  const availableWidth = stageWidth - padding * 2;
+  const availableHeight = stageHeight - padding * 2;
+
+  const scaleX = availableWidth / contentWidth;
+  const scaleY = availableHeight / contentHeight;
+  const scale = Math.max(minScale, Math.min(maxScale, Math.min(scaleX, scaleY)));
+
+  // Center the content
+  const offsetX = (stageWidth - contentWidth * scale) / 2 - bbox.minX * scale;
+  const offsetY = (stageHeight - contentHeight * scale) / 2 - bbox.minY * scale;
+
+  return { scale, offsetX, offsetY };
+}


### PR DESCRIPTION
## Summary
- **Proportional card sizing** in Layout view — cards sized based on real product dimensions (width_mm × depth_mm), 1mm = 1 world pixel
- **Zoom/pan** in both Layout and Power views — mouse wheel zoom centered on cursor, click-drag pan, pinch-to-zoom on touch devices
- **Auto-fit viewport** — fits all cards on initial load; "Fit" button to re-center anytime
- **Floating zoom controls** — +/−/Fit buttons with zoom percentage display
- Viewport state (zoom level + pan offset) persists per view across view switches and page refresh

## Test plan
- [x] Layout view: cards sized proportionally (large pedal = large card)
- [x] Layout view: products without dimensions show default size
- [x] Mouse wheel zooms centered on cursor in both views
- [x] Click-drag on empty canvas pans in both views
- [x] +/−/Fit buttons work correctly
- [x] Zoom level persists across view switches and page refresh
- [x] Dragging cards still works at all zoom levels
- [x] Power view: connection lines render correctly at all zoom levels
- [x] Power view: creating connections works (preview line follows cursor)
- [x] Power view: floating delete button and warning popover positioned correctly at all zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)