### PR TITLE
Plan: Rotation and z-index for Layout view cards

### DIFF
--- a/docs/plans/options/powerview-rotation.md
+++ b/docs/plans/options/powerview-rotation.md
@@ -1,0 +1,58 @@
+# Option: Rotation in PowerView (and other planning views)
+
+## Context
+
+Rotation in LayoutView is straightforward — cards rotate visually and there are no dependent elements like connection lines that need to track port positions.
+
+PowerView is more complex because `ConnectionLine` endpoints are computed independently from the rendered `PortDot` positions. Currently, `portPositions` is a `useMemo` that calculates absolute world coordinates using hardcoded offsets from each card's top-left corner:
+
+```typescript
+// Supply output ports — right edge of card
+x: pos.x + CARD_WIDTH - 2,
+y: pos.y + PORT_START_Y + i * PORT_SPACING,
+
+// Consumer input ports — left edge of card
+x: pos.x + 2,
+y: pos.y + CARD_HEIGHT / 2,
+```
+
+If we rotate a card, the visual port positions (rendered inside the card's Konva Group) rotate automatically via Konva's transform hierarchy, but the connection line endpoints stay at the unrotated positions — causing lines to detach from ports.
+
+## Option A: Refactor portPositions to read from rendered nodes (recommended)
+
+`PortDot` components are children of `ProductCard`, so they live inside the rotating Konva Group. Konva nodes expose `getAbsolutePosition()` which returns the node's position after all parent transforms (including rotation) are applied.
+
+**Approach:**
+1. Add refs to each `PortDot` Konva node
+2. After render, read `getAbsolutePosition()` from each port node
+3. Use those positions for `ConnectionLine` endpoints and hit-testing
+
+**Pros:**
+- Rotation comes for free — Konva's transform hierarchy handles the math
+- No manual vector rotation logic to maintain
+- Single source of truth for port positions (the rendered nodes themselves)
+
+**Cons:**
+- Requires an imperative bridge (refs + `useEffect` or second render pass)
+- Slightly less idiomatic React (reading from rendered nodes rather than pre-computing data)
+
+## Option B: Manually rotate port offset vectors
+
+Keep the current pre-computed `useMemo` approach but apply rotation math to the offset vectors when a card has a non-zero rotation.
+
+**Approach:**
+1. For each port, compute the offset from card center: `(offsetX, offsetY)`
+2. Apply 2D rotation to the offset: `(cos(θ)*dx - sin(θ)*dy, sin(θ)*dx + cos(θ)*dy)`
+3. Add back the card center to get world position
+
+**Pros:**
+- Stays within React's declarative model
+- No refs or second render pass needed
+
+**Cons:**
+- Duplicates rotation logic (Konva handles it for visuals, we recompute it for positions)
+- Must stay in sync with ProductCard's inner Group transform parameters
+
+## Recommendation
+
+Option A is cleaner long-term. It eliminates the duplicated position calculation entirely and makes the system resilient to future transform changes (e.g., if card sizing or pivot points change). The imperative bridge is a well-established React pattern for canvas libraries.

--- a/docs/plans/rotation-z-index.md
+++ b/docs/plans/rotation-z-index.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Product cards on the Layout canvas can be dragged but not rotated or reordered in depth. For pedalboard layout planning, users need to rotate pedals (e.g., turn a pedal sideways to fit) and control which card renders on top when cards overlap. These are todo items "Make objects rotateable" and "Enable objects to be sent forward or back on z-axis".
+Product cards on the Layout canvas can be dragged but not rotated or reordered in depth. For pedalboard layout planning, users need to rotate pedals (e.g., turn a pedal sideways to fit) and control which card renders on top when cards overlap. These are todo items "Make objects rotateable (Layout view)" and "Enable objects to be sent forward or back on z-axis (Layout view)".
 
 This plan covers **LayoutView only** as a v1. Extending rotation to PowerView requires refactoring how port positions are computed (see `docs/plans/options/powerview-rotation.md`). Z-index ordering for other views is straightforward and tracked separately in `todo.md`.
 

--- a/docs/plans/rotation-z-index.md
+++ b/docs/plans/rotation-z-index.md
@@ -1,0 +1,104 @@
+# Plan: Rotation and Z-Index for Layout View Cards
+
+## Context
+
+Product cards on the Layout canvas can be dragged but not rotated or reordered in depth. For pedalboard layout planning, users need to rotate pedals (e.g., turn a pedal sideways to fit) and control which card renders on top when cards overlap. These are todo items "Make objects rotateable" and "Enable objects to be sent forward or back on z-axis".
+
+Both features apply to **LayoutView only** — PowerView uses fixed port-position offsets for connection lines, and rotation/z-ordering would break those calculations without significant rework.
+
+## Files to modify
+
+1. **`apps/web/src/context/WorkbenchContext.tsx`** — Extend position storage type, add `updateCardTransform` method
+2. **`apps/web/src/components/Workbench/ProductCard.tsx`** — Add `rotation` prop with nested inner Group for center-pivot rotation
+3. **`apps/web/src/components/Workbench/LayoutView.tsx`** — Add card selection, keyboard handlers, z-index sort, rotation passing, keyboard hints overlay
+4. **`apps/web/src/utils/canvasUtils.ts`** — Rotation-aware bounding box for fit-all
+5. **`apps/web/src/components/Workbench/index.scss`** — Keyboard hints overlay styles
+
+## Implementation
+
+### 1. Extend position storage (`WorkbenchContext.tsx`)
+
+Change the position value type from `{ x: number; y: number }` to a named interface:
+
+```typescript
+export interface CardTransform {
+  x: number;
+  y: number;
+  rotation?: number;  // degrees (0, 90, 180, 270). Default 0.
+  zIndex?: number;    // layer order. Higher = on top. Default 0.
+}
+```
+
+Update `ViewPositions`, `getViewPositions` return type, and `updateViewPosition` to use `CardTransform`. Existing localStorage data is backward-compatible since `rotation` and `zIndex` are optional.
+
+Add a new `updateCardTransform(view, instanceId, patch: Partial<CardTransform>)` method that merges a partial update into the existing transform. This avoids overwriting rotation/zIndex on every drag-end (which only passes x/y). Expose it from the context.
+
+Keep `updateViewPosition(view, instanceId, x, y)` as-is for drag-end calls — it only sets x/y and preserves existing rotation/zIndex by merging.
+
+### 2. Add rotation to ProductCard (`ProductCard.tsx`)
+
+Add `rotation?: number` prop. Use a **nested inner Group** for center-pivot rotation so the outer Group's `(x, y)` stays as top-left corner (backward-compatible with saved positions):
+
+```
+<Group x={x} y={y} draggable ...>        ← outer: position + drag
+  <Group                                   ← inner: rotation around center
+    rotation={rotation ?? 0}
+    offsetX={width / 2}
+    offsetY={height / 2}
+    x={width / 2}
+    y={height / 2}
+  >
+    <Rect .../> <Text .../> {children}
+  </Group>
+</Group>
+```
+
+The inner Group translates to center, sets offset to center, then rotates — producing center-pivot rotation. The outer Group is unaffected, so drag and position work identically to before.
+
+### 3. Add selection + keyboard controls to LayoutView (`LayoutView.tsx`)
+
+**Card selection:** Add `selectedId` state. Pass `selected` and `onClick` to each ProductCard. Add `onStageClick` to CanvasBase to deselect when clicking empty canvas.
+
+**Keyboard shortcuts** (via `useEffect` + `keydown` listener, same pattern as PowerView):
+- **R** — Rotate selected card +90 degrees
+- **Shift+R** — Rotate selected card -90 degrees
+- **]** — Bring to front (set zIndex to max + 1)
+- **[** — Send to back (set zIndex to min - 1)
+- **Escape** — Deselect
+- **Delete/Backspace** — No action (avoid accidental deletion)
+
+**Z-index rendering order:** Sort rows by `zIndex` (from saved positions) before mapping to `<ProductCard>`. Lower zIndex renders first (behind).
+
+**Pass rotation:** Read `savedPositions[instanceId]?.rotation ?? 0` and pass to ProductCard.
+
+**Keyboard hints overlay:** When a card is selected, show a small HTML bar at the top of the canvas with available shortcuts (R rotate, ] front, [ back, Esc deselect). Style as a translucent bar with `pointer-events: none`.
+
+### 4. Rotation-aware bounding box (`canvasUtils.ts`)
+
+Extend `calculateBoundingBox` to accept optional `rotation` on each card. When rotation is non-zero, compute the 4 rotated corners around the card center and expand the bounding box to contain them. When rotation is 0, use the fast path (current logic). Update both call sites in LayoutView to pass rotation.
+
+### 5. Keyboard hints styles (`index.scss`)
+
+Add `.workbench__canvas-hints` — positioned absolute at top-center, translucent dark background, monospace font, small text, `pointer-events: none`.
+
+## What does NOT change
+
+- **PowerView** — No rotation or z-index support (port positions depend on fixed card geometry)
+- **CanvasBase** — Already supports `onStageClick`, no changes needed
+- **WorkbenchItem** — Has an unused `rotation` field from Phase 2 planning; leave it as-is (positions are stored in `viewPositions`, not `WorkbenchItem`)
+
+## Verification
+
+1. `npm run web:build` — compilation passes
+2. `npm run web:test` — all tests pass
+3. Manual testing:
+   - Click a card in Layout view → card shows selected state (border highlight)
+   - Press R → card rotates 90 degrees, visually pivoting around center
+   - Press R repeatedly → cycles through 0, 90, 180, 270
+   - Press Shift+R → rotates in the opposite direction
+   - Press ] → selected card renders on top of overlapping cards
+   - Press [ → selected card renders behind overlapping cards
+   - Drag a rotated card → card moves normally, rotation preserved
+   - Fit-all (zoom controls) → correctly fits rotated cards
+   - Refresh page → rotation and z-index persist from localStorage
+   - PowerView → unaffected, no rotation controls available

--- a/docs/plans/rotation-z-index.md
+++ b/docs/plans/rotation-z-index.md
@@ -4,7 +4,7 @@
 
 Product cards on the Layout canvas can be dragged but not rotated or reordered in depth. For pedalboard layout planning, users need to rotate pedals (e.g., turn a pedal sideways to fit) and control which card renders on top when cards overlap. These are todo items "Make objects rotateable" and "Enable objects to be sent forward or back on z-axis".
 
-Both features apply to **LayoutView only** — PowerView uses fixed port-position offsets for connection lines, and rotation/z-ordering would break those calculations without significant rework.
+This plan covers **LayoutView only** as a v1. Extending rotation to PowerView requires refactoring how port positions are computed (see `docs/plans/options/powerview-rotation.md`). Z-index ordering for other views is straightforward and tracked separately in `todo.md`.
 
 ## Files to modify
 

--- a/docs/plans/todo.md
+++ b/docs/plans/todo.md
@@ -24,8 +24,10 @@
 
 - [ ] **Unit toggle** — Enable toggle for units of measurement (mm ↔ inches)
 - [ ] **Product images** — Add images to views so users can see the product within the details view (in expanded row panels)
-- [ ] Make objects rotateable
-- [ ] Enable objects to be sent forward or back on z-axis
+- [ ] Make objects rotateable (Layout view — in progress via `docs/plans/rotation-z-index.md`)
+- [ ] Enable objects to be sent forward or back on z-axis (Layout view — in progress via `docs/plans/rotation-z-index.md`)
+- [ ] Add rotation to PowerView and other planning views (see `docs/plans/options/powerview-rotation.md`)
+- [ ] Add z-index ordering to PowerView and other planning views
 
 ## 7. API
 


### PR DESCRIPTION
## Summary
- Adds a design plan for card rotation (R / Shift+R) and z-index ordering (] / [) in the Layout canvas view
- Covers WorkbenchContext type changes, ProductCard rotation via nested Konva Group, keyboard shortcuts, rotation-aware bounding boxes, and keyboard hints overlay
- Scoped to Layout view only — PowerView is unaffected

## Test plan
- [x] Review plan for completeness and correctness
- [x] Approve before implementation begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)