### PR TITLE
Phase 1: Shared connection validation types

### DIFF
--- a/apps/web/src/__tests__/utils/powerUtils.test.ts
+++ b/apps/web/src/__tests__/utils/powerUtils.test.ts
@@ -79,25 +79,52 @@ describe('validateConnection', () => {
   it('returns error for voltage mismatch', () => {
     const result = validateConnection(baseOutput, { ...baseInput, voltage: '18V' });
     expect(result.status).toBe('error');
-    expect(result.warnings[0]).toMatch(/Voltage mismatch/);
+    expect(result.warnings[0].key).toBe('power:voltage-mismatch');
+    expect(result.warnings[0].severity).toBe('error');
+    expect(result.warnings[0].message).toMatch(/Voltage mismatch/);
   });
 
   it('returns error for current overload', () => {
     const result = validateConnection(baseOutput, baseInput, 600);
     expect(result.status).toBe('error');
-    expect(result.warnings[0]).toMatch(/Current overload/);
+    expect(result.warnings[0].key).toBe('power:current-overload');
+    expect(result.warnings[0].severity).toBe('error');
+    expect(result.warnings[0].message).toMatch(/Current overload/);
   });
 
   it('returns warning for polarity mismatch', () => {
     const result = validateConnection(baseOutput, { ...baseInput, polarity: 'Center Positive' });
     expect(result.status).toBe('warning');
-    expect(result.warnings[0]).toMatch(/Polarity mismatch/);
+    expect(result.warnings[0].key).toBe('power:polarity-mismatch');
+    expect(result.warnings[0].severity).toBe('warning');
+    expect(result.warnings[0].message).toMatch(/Polarity mismatch/);
+    expect(result.warnings[0].adapterImplication).toMatchObject({
+      fromConnectorType: '2.1mm barrel',
+      toConnectorType: '2.1mm barrel',
+      description: expect.stringMatching(/reversal/i),
+    });
   });
 
   it('returns warning for connector mismatch', () => {
     const result = validateConnection(baseOutput, { ...baseInput, connector_type: '2.5mm barrel' });
     expect(result.status).toBe('warning');
-    expect(result.warnings[0]).toMatch(/Connector mismatch/);
+    expect(result.warnings[0].key).toBe('power:connector-mismatch');
+    expect(result.warnings[0].severity).toBe('warning');
+    expect(result.warnings[0].message).toMatch(/Connector mismatch/);
+    expect(result.warnings[0].adapterImplication).toMatchObject({
+      fromConnectorType: '2.1mm barrel',
+      toConnectorType: '2.5mm barrel',
+    });
+  });
+
+  it('returns info notice for adjustable voltage supply', () => {
+    const adjustableOutput = { ...baseOutput, voltage: '9V/12V/18V' };
+    const result = validateConnection(adjustableOutput, baseInput);
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0].key).toBe('power:adjustable-voltage');
+    expect(result.warnings[0].severity).toBe('info');
+    expect(result.warnings[0].message).toMatch(/adjustable/);
+    expect(result.warnings[0].adapterImplication).toBeUndefined();
   });
 
   it('handles null values gracefully', () => {
@@ -106,5 +133,6 @@ describe('validateConnection', () => {
       { voltage: null, current_ma: null, polarity: null, connector_type: null },
     );
     expect(result.status).toBe('valid');
+    expect(result.warnings).toHaveLength(0);
   });
 });

--- a/apps/web/src/components/Workbench/PowerView.tsx
+++ b/apps/web/src/components/Workbench/PowerView.tsx
@@ -7,7 +7,8 @@ import {
   getPowerOutputJacks,
   assignPedalsToOutputs,
 } from '../../utils/powerAssignment';
-import { validateConnection, ConnectionValidation } from '../../utils/powerUtils';
+import { validateConnection } from '../../utils/powerUtils';
+import { ConnectionValidation, ConnectionWarning } from '../../utils/connectionValidation';
 import { Jack } from '../../utils/transformers';
 import { useCanvasViewport } from '../../hooks/useCanvasViewport';
 import { calculateBoundingBox } from '../../utils/canvasUtils';
@@ -79,7 +80,7 @@ const PowerView = ({ rows }: PowerViewProps) => {
   const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
   const [warningPopover, setWarningPopover] = useState<{
     connId: string;
-    warnings: string[];
+    warnings: ConnectionWarning[];
     x: number;
     y: number;
   } | null>(null);
@@ -375,7 +376,7 @@ const PowerView = ({ rows }: PowerViewProps) => {
 
           const validation = connectionValidations.get(conn.id) ?? { status: 'valid' as const, warnings: [] };
           const isAcknowledged = (conn.acknowledgedWarnings?.length ?? 0) > 0 &&
-            validation.warnings.every(w => conn.acknowledgedWarnings?.includes(w));
+            validation.warnings.every(w => conn.acknowledgedWarnings?.includes(w.key));
 
           return (
             <ConnectionLine
@@ -561,19 +562,19 @@ const PowerView = ({ rows }: PowerViewProps) => {
             }}
           >
             <div className="workbench__power-popover-warnings">
-              {warningPopover.warnings.map((w, i) => {
+              {warningPopover.warnings.map((w) => {
                 const conn = connections.find(c => c.id === warningPopover.connId);
-                const alreadyAcked = conn?.acknowledgedWarnings?.includes(w);
-                const isVoltageNotice = w.startsWith('This output is adjustable');
+                const alreadyAcked = conn?.acknowledgedWarnings?.includes(w.key);
+                const isVoltageNotice = w.key === 'power:adjustable-voltage';
                 return (
-                  <div key={i} className="workbench__power-popover-warning">
-                    <span>{w}</span>
+                  <div key={w.key} className="workbench__power-popover-warning">
+                    <span>{w.message}</span>
                     {alreadyAcked ? (
                       <span className="workbench__power-popover-acked">Acknowledged</span>
                     ) : (
                       <button
                         className="workbench__power-popover-btn"
-                        onClick={() => acknowledgeWarning(warningPopover.connId, w)}
+                        onClick={() => acknowledgeWarning(warningPopover.connId, w.key)}
                       >
                         {isVoltageNotice ? 'Got it' : 'I have this adapter'}
                       </button>

--- a/apps/web/src/utils/connectionValidation.ts
+++ b/apps/web/src/utils/connectionValidation.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared validation types for all connection categories (power, audio, MIDI, control).
+ *
+ * Validators in powerUtils, audioUtils, midiUtils, and controlUtils all return
+ * ConnectionValidation so the UI can handle warnings uniformly across categories.
+ */
+
+export type ValidationSeverity = 'error' | 'warning' | 'info';
+
+export interface ConnectionWarning {
+  /** Stable identifier used to track acknowledgements. Format: `category:rule-name`. */
+  key: string;
+  severity: ValidationSeverity;
+  message: string;
+  /** Present when this warning implies a physical adapter is needed. */
+  adapterImplication?: {
+    fromConnectorType: string;
+    toConnectorType: string;
+    description: string;
+  };
+}
+
+export interface ConnectionValidation {
+  status: 'valid' | 'warning' | 'error';
+  warnings: ConnectionWarning[];
+}

--- a/apps/web/src/utils/powerUtils.ts
+++ b/apps/web/src/utils/powerUtils.ts
@@ -1,7 +1,8 @@
 /**
- * Shared normalization utilities for power-related comparisons.
- * Used by PowerBudgetInsight (workbench) and PowerSupplies (catalog filter).
+ * Shared normalization and validation utilities for power connections.
+ * Used by PowerView (workbench) and PowerSupplies (catalog filter).
  */
+import { ConnectionWarning, ConnectionValidation } from './connectionValidation';
 
 /** Lowercase + replace spaces with hyphens: "Center Negative" -> "center-negative" */
 export function normalizePolarity(p: string): string {
@@ -55,24 +56,23 @@ export function voltagesCompatible(supplyVoltage: string, consumerVoltage: strin
 }
 
 /** Validate a single connection between a supply output jack and a consumer input jack. */
-export interface ConnectionValidation {
-  status: 'valid' | 'warning' | 'error';
-  warnings: string[];
-}
-
 export function validateConnection(
   outputJack: { voltage: string | null; current_ma: number | null; polarity: string | null; connector_type: string | null },
   inputJack: { voltage: string | null; current_ma: number | null; polarity: string | null; connector_type: string | null },
   /** Total current draw of all consumers connected to this output (including this one) */
   totalCurrentOnOutput?: number,
 ): ConnectionValidation {
-  const warnings: string[] = [];
+  const warnings: ConnectionWarning[] = [];
   let hasError = false;
 
   // Voltage check
   if (outputJack.voltage && inputJack.voltage) {
     if (!voltagesCompatible(outputJack.voltage, inputJack.voltage)) {
-      warnings.push(`Voltage mismatch: supply ${outputJack.voltage} vs pedal ${inputJack.voltage}`);
+      warnings.push({
+        key: 'power:voltage-mismatch',
+        severity: 'error',
+        message: `Voltage mismatch: supply ${outputJack.voltage} vs pedal ${inputJack.voltage}`,
+      });
       hasError = true;
     }
   }
@@ -80,7 +80,11 @@ export function validateConnection(
   // Current check
   if (totalCurrentOnOutput != null && outputJack.current_ma != null) {
     if (totalCurrentOnOutput > outputJack.current_ma) {
-      warnings.push(`Current overload: ${totalCurrentOnOutput}mA needed, output provides ${outputJack.current_ma}mA`);
+      warnings.push({
+        key: 'power:current-overload',
+        severity: 'error',
+        message: `Current overload: ${totalCurrentOnOutput}mA needed, output provides ${outputJack.current_ma}mA`,
+      });
       hasError = true;
     }
   }
@@ -89,27 +93,49 @@ export function validateConnection(
     return { status: 'error', warnings };
   }
 
-  // Polarity check (warning, not error — user can get an adapter)
+  // Polarity check (warning, not error — user can get a reversal cable)
   if (outputJack.polarity && inputJack.polarity) {
     if (normalizePolarity(outputJack.polarity) !== normalizePolarity(inputJack.polarity)) {
-      warnings.push(`Polarity mismatch: supply ${outputJack.polarity}, pedal ${inputJack.polarity} — reversal cable needed`);
+      warnings.push({
+        key: 'power:polarity-mismatch',
+        severity: 'warning',
+        message: `Polarity mismatch: supply ${outputJack.polarity}, pedal ${inputJack.polarity} — reversal cable needed`,
+        adapterImplication: {
+          fromConnectorType: outputJack.connector_type ?? 'unknown',
+          toConnectorType: inputJack.connector_type ?? 'unknown',
+          description: `Polarity reversal cable (${outputJack.polarity} to ${inputJack.polarity})`,
+        },
+      });
     }
   }
 
   // Connector check (warning, not error — user can get an adapter)
   if (outputJack.connector_type && inputJack.connector_type) {
     if (normalizeConnector(outputJack.connector_type) !== normalizeConnector(inputJack.connector_type)) {
-      warnings.push(`Connector mismatch: supply ${outputJack.connector_type}, pedal ${inputJack.connector_type} — adapter needed`);
+      warnings.push({
+        key: 'power:connector-mismatch',
+        severity: 'warning',
+        message: `Connector mismatch: supply ${outputJack.connector_type}, pedal ${inputJack.connector_type} — adapter needed`,
+        adapterImplication: {
+          fromConnectorType: outputJack.connector_type,
+          toConnectorType: inputJack.connector_type,
+          description: `${outputJack.connector_type} to ${inputJack.connector_type} power adapter`,
+        },
+      });
     }
   }
 
   // Adjustable voltage notice — supply offers multiple voltages but pedal needs a specific one
-  if (outputJack.voltage && inputJack.voltage && !hasError) {
+  if (outputJack.voltage && inputJack.voltage) {
     const supplyTokens = voltageTokensFromJack(outputJack.voltage);
     const consumerTokens = voltageTokensFromJack(inputJack.voltage);
     const supplyIsAdjustable = supplyTokens.length > 1 || supplyTokens.some(t => t.includes('-'));
     if (supplyIsAdjustable && consumerTokens.length === 1) {
-      warnings.push(`This output is adjustable — set it to ${inputJack.voltage} for this pedal`);
+      warnings.push({
+        key: 'power:adjustable-voltage',
+        severity: 'info',
+        message: `This output is adjustable — set it to ${inputJack.voltage} for this pedal`,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

- Creates `utils/connectionValidation.ts` with `ConnectionWarning`, `ConnectionValidation`, and `ValidationSeverity` types shared across all connection categories (power, audio, MIDI, control)
- Migrates `powerUtils.ts` from `warnings: string[]` to `warnings: ConnectionWarning[]`
- Warning keys follow the `category:rule-name` convention (`power:voltage-mismatch`, `power:polarity-mismatch`, etc.)
- Adds `adapterImplication` to polarity-mismatch and connector-mismatch warnings, so Phase 5 (shopping list) can derive adapter requirements without additional computation
- Updates `PowerView.tsx` to import types directly from `connectionValidation.ts` (not re-exported through `powerUtils`)
- Updates tests to assert on the structured warning shape including `key`, `severity`, `message`, and `adapterImplication`

## Test plan

- [x] All 19 tests pass (`npm test`)
- [x] Production build compiles cleanly (`npm run web:build`)
- [x] New test case added for adjustable voltage `info` notice
- [x] Polarity and connector mismatch tests verify `adapterImplication` shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)