### PR TITLE
Phase 2: Audio Connections View

### DIFF
--- a/apps/web/src/__tests__/utils/audioUtils.test.ts
+++ b/apps/web/src/__tests__/utils/audioUtils.test.ts
@@ -1,0 +1,252 @@
+import {
+  getAudioInputJacks,
+  getAudioOutputJacks,
+  hasAudioJacks,
+  getStereoPartner,
+  validateAudioConnection,
+  wouldCreateCycle,
+} from '../../utils/audioUtils';
+import { Jack } from '../../utils/transformers';
+import { AudioConnection } from '../../types/connections';
+
+// --- Test data helpers ---
+
+function makeJack(overrides: Partial<Jack>): Jack {
+  return {
+    id: 1,
+    category: null,
+    direction: null,
+    jack_name: null,
+    position: null,
+    connector_type: null,
+    impedance_ohms: null,
+    voltage: null,
+    current_ma: null,
+    polarity: null,
+    function_desc: null,
+    is_isolated: null,
+    is_buffered: null,
+    has_ground_lift: null,
+    has_phase_invert: null,
+    group_id: null,
+    ...overrides,
+  };
+}
+
+function makeConnection(overrides: Partial<AudioConnection>): AudioConnection {
+  return {
+    id: 'conn-1',
+    sourceJackId: 1,
+    targetJackId: 2,
+    sourceInstanceId: 'inst-a',
+    targetInstanceId: 'inst-b',
+    orderIndex: 0,
+    parallelPathId: null,
+    fxLoopGroupId: null,
+    signalMode: 'mono',
+    stereoPairConnectionId: null,
+    waypoints: [],
+    ...overrides,
+  };
+}
+
+// --- getAudioInputJacks ---
+
+describe('getAudioInputJacks', () => {
+  it('returns only audio input jacks', () => {
+    const jacks = [
+      makeJack({ id: 1, category: 'audio', direction: 'input' }),
+      makeJack({ id: 2, category: 'audio', direction: 'output' }),
+      makeJack({ id: 3, category: 'power', direction: 'input' }),
+    ];
+    const result = getAudioInputJacks({ jacks });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+  });
+
+  it('returns empty array when no audio input jacks', () => {
+    const jacks = [makeJack({ id: 1, category: 'power', direction: 'input' })];
+    expect(getAudioInputJacks({ jacks })).toEqual([]);
+  });
+});
+
+// --- getAudioOutputJacks ---
+
+describe('getAudioOutputJacks', () => {
+  it('returns only audio output jacks', () => {
+    const jacks = [
+      makeJack({ id: 1, category: 'audio', direction: 'output' }),
+      makeJack({ id: 2, category: 'audio', direction: 'input' }),
+      makeJack({ id: 3, category: 'power', direction: 'output' }),
+    ];
+    const result = getAudioOutputJacks({ jacks });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+  });
+
+  it('returns empty array when no audio output jacks', () => {
+    expect(getAudioOutputJacks({ jacks: [] })).toEqual([]);
+  });
+});
+
+// --- hasAudioJacks ---
+
+describe('hasAudioJacks', () => {
+  it('returns false for power-only row', () => {
+    const jacks = [makeJack({ id: 1, category: 'power', direction: 'input' })];
+    expect(hasAudioJacks({ jacks })).toBe(false);
+  });
+
+  it('returns true for row with audio jacks', () => {
+    const jacks = [
+      makeJack({ id: 1, category: 'power', direction: 'input' }),
+      makeJack({ id: 2, category: 'audio', direction: 'output' }),
+    ];
+    expect(hasAudioJacks({ jacks })).toBe(true);
+  });
+
+  it('returns false for empty jacks array', () => {
+    expect(hasAudioJacks({ jacks: [] })).toBe(false);
+  });
+});
+
+// --- getStereoPartner ---
+
+describe('getStereoPartner', () => {
+  it('returns partner jack sharing the same group_id', () => {
+    const jack = makeJack({ id: 1, group_id: 'stereo-group-1' });
+    const partner = makeJack({ id: 2, group_id: 'stereo-group-1' });
+    const allJacks = [jack, partner];
+    expect(getStereoPartner(jack, allJacks)).toBe(partner);
+  });
+
+  it('returns undefined when jack has no group_id', () => {
+    const jack = makeJack({ id: 1, group_id: null });
+    const other = makeJack({ id: 2, group_id: null });
+    expect(getStereoPartner(jack, [jack, other])).toBeUndefined();
+  });
+
+  it('returns undefined when group_id set but no other jack shares it', () => {
+    const jack = makeJack({ id: 1, group_id: 'group-x' });
+    const other = makeJack({ id: 2, group_id: 'group-y' });
+    expect(getStereoPartner(jack, [jack, other])).toBeUndefined();
+  });
+
+  it('does not return the same jack as its own partner', () => {
+    const jack = makeJack({ id: 1, group_id: 'group-solo' });
+    expect(getStereoPartner(jack, [jack])).toBeUndefined();
+  });
+});
+
+// --- wouldCreateCycle ---
+
+describe('wouldCreateCycle', () => {
+  it('returns false for unconnected items', () => {
+    expect(wouldCreateCycle('inst-a', 'inst-b', [])).toBe(false);
+  });
+
+  it('returns false when no path exists from target to source', () => {
+    const conns = [makeConnection({ sourceInstanceId: 'inst-b', targetInstanceId: 'inst-c' })];
+    expect(wouldCreateCycle('inst-a', 'inst-b', conns)).toBe(false);
+  });
+
+  it('returns true when adding connection would close a loop', () => {
+    // a → b → c, adding c → a would be a cycle
+    const conns = [
+      makeConnection({ id: 'c1', sourceInstanceId: 'inst-a', targetInstanceId: 'inst-b' }),
+      makeConnection({ id: 'c2', sourceInstanceId: 'inst-b', targetInstanceId: 'inst-c' }),
+    ];
+    expect(wouldCreateCycle('inst-c', 'inst-a', conns)).toBe(true);
+  });
+
+  it('returns true for a direct self-loop', () => {
+    expect(wouldCreateCycle('inst-a', 'inst-a', [])).toBe(true);
+  });
+});
+
+// --- validateAudioConnection ---
+
+const validSource = { connector_type: '1/4" TS', group_id: null, impedance_ohms: null };
+const validTarget = { connector_type: '1/4" TS', group_id: null, impedance_ohms: null };
+
+describe('validateAudioConnection', () => {
+  it('returns valid when all checks pass', () => {
+    const result = validateAudioConnection(
+      validSource, validTarget, 'mono', 'mono', [], 'inst-a', 'inst-b',
+    );
+    expect(result.status).toBe('valid');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('warns on connector mismatch with adapterImplication', () => {
+    const source = { ...validSource, connector_type: '1/4" TS' };
+    const target = { ...validTarget, connector_type: 'XLR' };
+    const result = validateAudioConnection(
+      source, target, 'mono', 'mono', [], 'inst-a', 'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    const w = result.warnings.find(w => w.key === 'audio:connector-mismatch');
+    expect(w).toBeDefined();
+    expect(w?.adapterImplication).toBeDefined();
+    expect(w?.adapterImplication?.fromConnectorType).toBe('1/4" TS');
+    expect(w?.adapterImplication?.toConnectorType).toBe('XLR');
+  });
+
+  it('warns on mono-to-stereo without adapterImplication', () => {
+    const result = validateAudioConnection(
+      validSource, validTarget, 'mono', 'stereo', [], 'inst-a', 'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    const w = result.warnings.find(w => w.key === 'audio:mono-to-stereo');
+    expect(w).toBeDefined();
+    expect(w?.adapterImplication).toBeUndefined();
+  });
+
+  it('warns on stereo-to-mono without adapterImplication', () => {
+    const result = validateAudioConnection(
+      validSource, validTarget, 'stereo', 'mono', [], 'inst-a', 'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    const w = result.warnings.find(w => w.key === 'audio:stereo-to-mono');
+    expect(w).toBeDefined();
+    expect(w?.adapterImplication).toBeUndefined();
+  });
+
+  it('warns on impedance mismatch when both jacks have impedance_ohms', () => {
+    const source = { ...validSource, impedance_ohms: 10 };
+    const target = { ...validTarget, impedance_ohms: 10000 };
+    const result = validateAudioConnection(
+      source, target, 'mono', 'mono', [], 'inst-a', 'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    expect(result.warnings.some(w => w.key === 'audio:impedance-mismatch')).toBe(true);
+  });
+
+  it('does not warn on impedance when only one jack has impedance_ohms', () => {
+    const source = { ...validSource, impedance_ohms: 10 };
+    const target = { ...validTarget, impedance_ohms: null };
+    const result = validateAudioConnection(
+      source, target, 'mono', 'mono', [], 'inst-a', 'inst-b',
+    );
+    expect(result.warnings.some(w => w.key === 'audio:impedance-mismatch')).toBe(false);
+  });
+
+  it('handles null connector types gracefully (no mismatch warning)', () => {
+    const source = { connector_type: null, group_id: null, impedance_ohms: null };
+    const target = { connector_type: null, group_id: null, impedance_ohms: null };
+    const result = validateAudioConnection(
+      source, target, 'mono', 'mono', [], 'inst-a', 'inst-b',
+    );
+    expect(result.warnings.some(w => w.key === 'audio:connector-mismatch')).toBe(false);
+  });
+
+  it('returns error status on circular connection', () => {
+    // a → b already exists; trying to add b → a
+    const conns = [makeConnection({ sourceInstanceId: 'inst-a', targetInstanceId: 'inst-b' })];
+    const result = validateAudioConnection(
+      validSource, validTarget, 'mono', 'mono', conns, 'inst-b', 'inst-a',
+    );
+    expect(result.status).toBe('error');
+    expect(result.warnings.some(w => w.key === 'audio:circular-connection')).toBe(true);
+  });
+});

--- a/apps/web/src/components/Workbench/AudioView.tsx
+++ b/apps/web/src/components/Workbench/AudioView.tsx
@@ -1,0 +1,933 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { Group, Rect, Text, Circle } from 'react-konva';
+import Konva from 'konva';
+import { useWorkbench } from '../../context/WorkbenchContext';
+import { AudioConnection, VirtualNode } from '../../types/connections';
+import { WorkbenchRow } from './WorkbenchTable';
+import {
+  getAudioInputJacks,
+  getAudioOutputJacks,
+  hasAudioJacks,
+  getStereoPartner,
+  validateAudioConnection,
+} from '../../utils/audioUtils';
+import { ConnectionValidation, ConnectionWarning } from '../../utils/connectionValidation';
+import { Jack } from '../../utils/transformers';
+import { useCanvasViewport } from '../../hooks/useCanvasViewport';
+import { calculateBoundingBox } from '../../utils/canvasUtils';
+import CanvasBase from './CanvasBase';
+import ProductCard, { CARD_WIDTH, CARD_HEIGHT } from './ProductCard';
+import PortDot from './PortDot';
+import ConnectionLine from './ConnectionLine';
+import ZoomControls from './ZoomControls';
+
+const VIEW_KEY = 'audio';
+
+const PORT_SPACING = 18;
+const PORT_START_Y = 12;
+
+const VIRTUAL_NODE_WIDTH = 100;
+const VIRTUAL_NODE_HEIGHT = 48;
+
+// Guitar on right, amp on left — right-to-left signal flow
+const DEFAULT_AMP_X = 40;
+const DEFAULT_ITEM_X_START = 240;
+const DEFAULT_ITEM_X_STEP = 200;
+const DEFAULT_GUITAR_X = (n: number) => DEFAULT_ITEM_X_START + n * DEFAULT_ITEM_X_STEP + 40;
+const DEFAULT_CENTER_Y = 200;
+
+/** Composite key for a port on a specific instance */
+function portKey(instanceId: string, jackId: number | string): string {
+  return `${instanceId}:${jackId}`;
+}
+
+/** Virtual jack for a virtual node treated as a real audio jack for validation */
+function virtualJack(connectorType: string) {
+  return {
+    connector_type: connectorType,
+    group_id: null as string | null,
+    impedance_ohms: null as number | null,
+  };
+}
+
+interface PendingConnection {
+  jackId: number | string;
+  instanceId: string;
+  compositeKey: string;
+  direction: 'output' | 'input';
+}
+
+interface StereoPrompt {
+  sourceJackId: number | string;
+  sourceInstanceId: string;
+  targetJackId: number | string;
+  targetInstanceId: string;
+  x: number; // screen coords
+  y: number;
+}
+
+interface AudioViewProps {
+  rows: WorkbenchRow[];
+}
+
+const AudioView = ({ rows }: AudioViewProps) => {
+  const {
+    getViewPositions,
+    updateViewPosition,
+    addAudioConnection,
+    removeAudioConnection,
+    setAudioConnections,
+    acknowledgeAudioWarning,
+    updateAudioConnectionWaypoints,
+    setVirtualNodes,
+    activeWorkbench,
+  } = useWorkbench();
+
+  const savedPositions = getViewPositions(VIEW_KEY);
+  const connections: AudioConnection[] = activeWorkbench.audioConnections ?? [];
+  const virtualNodes: VirtualNode[] = activeWorkbench.virtualNodes ?? [];
+
+  const viewport = useCanvasViewport(VIEW_KEY);
+  const [stageDims, setStageDims] = useState({ width: 800, height: 600 });
+
+  const handleDimensionsChange = useCallback((width: number, height: number) => {
+    setStageDims({ width, height });
+  }, []);
+
+  // Auto-init virtual nodes (guitar + amp) on first mount
+  useEffect(() => {
+    if (!activeWorkbench.virtualNodes || activeWorkbench.virtualNodes.length === 0) {
+      setVirtualNodes([
+        {
+          instanceId: 'virtual:guitar-1',
+          nodeType: 'guitar_input',
+          label: 'Guitar',
+          virtualJackId: 'virtual-jack:guitar-out',
+          connectorType: '1/4" TS',
+        },
+        {
+          instanceId: 'virtual:amp-1',
+          nodeType: 'amp_input',
+          label: 'Amp',
+          virtualJackId: 'virtual-jack:amp-in',
+          connectorType: '1/4" TS',
+        },
+      ]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Interaction state
+  const [pendingSource, setPendingSource] = useState<PendingConnection | null>(null);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+  const [warningPopover, setWarningPopover] = useState<{
+    connId: string;
+    warnings: ConnectionWarning[];
+    x: number;
+    y: number;
+  } | null>(null);
+  const [stereoPrompt, setStereoPrompt] = useState<StereoPrompt | null>(null);
+  const [editingNodeId, setEditingNodeId] = useState<string | null>(null);
+  const [editingNodeLabel, setEditingNodeLabel] = useState('');
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  // Rows that have audio jacks
+  const audioRows = useMemo(() => rows.filter(hasAudioJacks), [rows]);
+
+  // Jack lookup by id
+  const jackMap = useMemo(() => {
+    const map = new Map<number, Jack>();
+    for (const row of rows) {
+      for (const jack of row.jacks) {
+        map.set(jack.id, jack);
+      }
+    }
+    return map;
+  }, [rows]);
+
+  // Row lookup by instanceId
+  const rowMap = useMemo(() => {
+    const map = new Map<string, WorkbenchRow>();
+    for (const row of rows) map.set(row.instanceId, row);
+    return map;
+  }, [rows]);
+
+  // Default positions for audio rows
+  const audioRowEntries = useMemo(() => {
+    return audioRows.map((row, i) => ({
+      instanceId: row.instanceId,
+      row,
+      defaultX: DEFAULT_ITEM_X_START + i * DEFAULT_ITEM_X_STEP,
+      defaultY: DEFAULT_CENTER_Y,
+    }));
+  }, [audioRows]);
+
+  const getPosition = useCallback((instanceId: string, fallbackX: number, fallbackY: number) => {
+    return savedPositions[instanceId] ?? { x: fallbackX, y: fallbackY };
+  }, [savedPositions]);
+
+  // Port absolute positions (world coords) — keyed by portKey
+  const portPositions = useMemo(() => {
+    const map = new Map<string, { x: number; y: number }>();
+
+    // Real product cards
+    for (const entry of audioRowEntries) {
+      const pos = getPosition(entry.instanceId, entry.defaultX, entry.defaultY);
+      const inputJacks = getAudioInputJacks(entry.row);
+      const outputJacks = getAudioOutputJacks(entry.row);
+
+      // Outputs on left (x ≈ 2), inputs on right (x ≈ CARD_WIDTH - 2)
+      outputJacks.forEach((jack, i) => {
+        map.set(portKey(entry.instanceId, jack.id), {
+          x: pos.x + 2,
+          y: pos.y + PORT_START_Y + i * PORT_SPACING,
+        });
+      });
+      inputJacks.forEach((jack, i) => {
+        map.set(portKey(entry.instanceId, jack.id), {
+          x: pos.x + CARD_WIDTH - 2,
+          y: pos.y + PORT_START_Y + i * PORT_SPACING,
+        });
+      });
+    }
+
+    // Virtual nodes
+    const numAudio = audioRows.length;
+    virtualNodes.forEach((node) => {
+      const isGuitar = node.nodeType === 'guitar_input';
+      const fallbackX = isGuitar
+        ? DEFAULT_GUITAR_X(numAudio)
+        : DEFAULT_AMP_X;
+      const pos = getPosition(node.instanceId, fallbackX, DEFAULT_CENTER_Y);
+      // Guitar: output on left side; Amp: input on right side
+      const portX = isGuitar
+        ? pos.x + 2
+        : pos.x + VIRTUAL_NODE_WIDTH - 2;
+      map.set(portKey(node.instanceId, node.virtualJackId), {
+        x: portX,
+        y: pos.y + VIRTUAL_NODE_HEIGHT / 2,
+      });
+    });
+
+    return map;
+  }, [audioRowEntries, virtualNodes, getPosition, audioRows.length]);
+
+  // Validate connections
+  const connectionValidations = useMemo(() => {
+    const map = new Map<string, ConnectionValidation>();
+    for (const conn of connections) {
+      const isSourceVirtual = typeof conn.sourceJackId === 'string';
+      const isTargetVirtual = typeof conn.targetJackId === 'string';
+
+      const sourceNode = isSourceVirtual
+        ? virtualNodes.find(n => n.virtualJackId === conn.sourceJackId)
+        : null;
+      const targetNode = isTargetVirtual
+        ? virtualNodes.find(n => n.virtualJackId === conn.targetJackId)
+        : null;
+
+      const sourceJackData = isSourceVirtual && sourceNode
+        ? virtualJack(sourceNode.connectorType)
+        : jackMap.get(conn.sourceJackId as number) ?? null;
+      const targetJackData = isTargetVirtual && targetNode
+        ? virtualJack(targetNode.connectorType)
+        : jackMap.get(conn.targetJackId as number) ?? null;
+
+      if (sourceJackData && targetJackData) {
+        map.set(conn.id, validateAudioConnection(
+          sourceJackData,
+          targetJackData,
+          conn.signalMode,
+          conn.signalMode,
+          connections.filter(c => c.id !== conn.id),
+          conn.sourceInstanceId,
+          conn.targetInstanceId,
+        ));
+      } else {
+        map.set(conn.id, { status: 'valid' as const, warnings: [] });
+      }
+    }
+    return map;
+  }, [connections, virtualNodes, jackMap]);
+
+  const handleDragEnd = useCallback((instanceId: string, x: number, y: number) => {
+    updateViewPosition(VIEW_KEY, instanceId, x, y);
+  }, [updateViewPosition]);
+
+  // Derive signal mode for a real jack
+  const getSignalMode = useCallback((jack: Jack, row: WorkbenchRow): 'mono' | 'stereo' => {
+    if (!jack.group_id) return 'mono';
+    const partner = getStereoPartner(jack, row.jacks);
+    return partner ? 'stereo' : 'mono';
+  }, []);
+
+  // --- Connection interaction ---
+
+  const handlePortClick = useCallback((instanceId: string, jackId: number | string, direction: 'output' | 'input') => {
+    const key = portKey(instanceId, jackId);
+
+    if (!pendingSource) {
+      setPendingSource({ jackId, instanceId, compositeKey: key, direction });
+      setMousePos(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+      setStereoPrompt(null);
+    } else if (pendingSource.compositeKey === key) {
+      // Clicked same port — cancel
+      setPendingSource(null);
+      setMousePos(null);
+    } else if (pendingSource.direction === direction) {
+      // Same direction — swap pending to new port
+      setPendingSource({ jackId, instanceId, compositeKey: key, direction });
+      setMousePos(null);
+    } else {
+      // Valid pair — determine source (output) and target (input)
+      const sourceJackId = direction === 'input' ? pendingSource.jackId : jackId;
+      const targetJackId = direction === 'input' ? jackId : pendingSource.jackId;
+      const sourceInstanceId = direction === 'input' ? pendingSource.instanceId : instanceId;
+      const targetInstanceId = direction === 'input' ? instanceId : pendingSource.instanceId;
+
+      // Check if both are real jacks with group_id for stereo prompt
+      const sourceJack = typeof sourceJackId === 'number' ? jackMap.get(sourceJackId) : null;
+      const targetJack = typeof targetJackId === 'number' ? jackMap.get(targetJackId) : null;
+      const sourceRow = rowMap.get(sourceInstanceId);
+      const targetRow = rowMap.get(targetInstanceId);
+      const sourceHasStereo = sourceJack && sourceRow
+        ? sourceJack.group_id !== null && !!getStereoPartner(sourceJack, sourceRow.jacks)
+        : false;
+      const targetHasStereo = targetJack && targetRow
+        ? targetJack.group_id !== null && !!getStereoPartner(targetJack, targetRow.jacks)
+        : false;
+
+      if (sourceHasStereo && targetHasStereo) {
+        // Show stereo prompt at midpoint (screen coords)
+        const srcPos = portPositions.get(portKey(sourceInstanceId, sourceJackId));
+        const tgtPos = portPositions.get(portKey(targetInstanceId, targetJackId));
+        const midWorld = srcPos && tgtPos
+          ? { x: (srcPos.x + tgtPos.x) / 2, y: (srcPos.y + tgtPos.y) / 2 }
+          : { x: stageDims.width / 2, y: stageDims.height / 2 };
+        const midScreen = viewport.worldToScreen(midWorld.x, midWorld.y);
+
+        setStereoPrompt({
+          sourceJackId,
+          sourceInstanceId,
+          targetJackId,
+          targetInstanceId,
+          x: midScreen.x,
+          y: midScreen.y - 40,
+        });
+        setPendingSource(null);
+        setMousePos(null);
+      } else {
+        createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'mono', null);
+        setPendingSource(null);
+        setMousePos(null);
+      }
+    }
+  }, [pendingSource, jackMap, rowMap, portPositions, viewport, stageDims]);
+
+  const createConnection = useCallback((
+    sourceJackId: number | string,
+    sourceInstanceId: string,
+    targetJackId: number | string,
+    targetInstanceId: string,
+    signalMode: 'mono' | 'stereo',
+    stereoPairConnectionId: string | null,
+  ) => {
+    addAudioConnection({
+      sourceJackId,
+      targetJackId,
+      sourceInstanceId,
+      targetInstanceId,
+      orderIndex: connections.length,
+      parallelPathId: null,
+      fxLoopGroupId: null,
+      signalMode,
+      stereoPairConnectionId,
+      waypoints: [],
+    });
+  }, [addAudioConnection, connections.length]);
+
+  const handleStereoConfirm = useCallback((asStereo: boolean) => {
+    if (!stereoPrompt) return;
+    const { sourceJackId, sourceInstanceId, targetJackId, targetInstanceId } = stereoPrompt;
+
+    if (asStereo) {
+      const srcJack = typeof sourceJackId === 'number' ? jackMap.get(sourceJackId) : null;
+      const tgtJack = typeof targetJackId === 'number' ? jackMap.get(targetJackId) : null;
+      const srcRow = rowMap.get(sourceInstanceId);
+      const tgtRow = rowMap.get(targetInstanceId);
+      const srcPartner = srcJack && srcRow ? getStereoPartner(srcJack, srcRow.jacks) : undefined;
+      const tgtPartner = tgtJack && tgtRow ? getStereoPartner(tgtJack, tgtRow.jacks) : undefined;
+
+      const primaryId = crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-primary`;
+      addAudioConnection({
+        sourceJackId,
+        targetJackId,
+        sourceInstanceId,
+        targetInstanceId,
+        orderIndex: connections.length,
+        parallelPathId: null,
+        fxLoopGroupId: null,
+        signalMode: 'stereo',
+        stereoPairConnectionId: null,
+        waypoints: [],
+      });
+
+      if (srcPartner && tgtPartner) {
+        addAudioConnection({
+          sourceJackId: srcPartner.id,
+          targetJackId: tgtPartner.id,
+          sourceInstanceId,
+          targetInstanceId,
+          orderIndex: connections.length + 1,
+          parallelPathId: null,
+          fxLoopGroupId: null,
+          signalMode: 'stereo',
+          stereoPairConnectionId: primaryId,
+          waypoints: [],
+        });
+      }
+    } else {
+      createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'mono', null);
+    }
+
+    setStereoPrompt(null);
+  }, [stereoPrompt, jackMap, rowMap, addAudioConnection, connections.length, createConnection]);
+
+  // Mouse tracking for preview line
+  const handleStageMouseMove = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!pendingSource) return;
+    const stage = e.target.getStage();
+    if (stage) {
+      const pos = stage.getPointerPosition();
+      if (pos) {
+        const world = viewport.screenToWorld(pos.x, pos.y);
+        setMousePos(world);
+      }
+    }
+  }, [pendingSource, viewport]);
+
+  const handleStageClick = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (e.target === e.target.getStage()) {
+      setPendingSource(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+      setStereoPrompt(null);
+    }
+  }, []);
+
+  const handleConnectionClick = useCallback((connId: string) => {
+    const validation = connectionValidations.get(connId);
+    const conn = connections.find(c => c.id === connId);
+
+    if (validation && validation.warnings.length > 0 && conn) {
+      const sourcePos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+      const targetPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+      if (sourcePos && targetPos) {
+        setWarningPopover({
+          connId,
+          warnings: validation.warnings,
+          x: (sourcePos.x + targetPos.x) / 2,
+          y: (sourcePos.y + targetPos.y) / 2 - 30,
+        });
+      }
+    }
+
+    setSelectedConnectionId(connId);
+    setPendingSource(null);
+    setStereoPrompt(null);
+  }, [connectionValidations, connections, portPositions]);
+
+  // Add waypoint on dblclick of a connection line
+  const handleConnectionDblClick = useCallback((connId: string, e: Konva.KonvaEventObject<MouseEvent>) => {
+    const conn = connections.find(c => c.id === connId);
+    if (!conn) return;
+
+    const stage = (e.target as Konva.Node).getStage();
+    if (!stage) return;
+    const pos = stage.getPointerPosition();
+    if (!pos) return;
+    const world = viewport.screenToWorld(pos.x, pos.y);
+
+    // Insert at nearest segment
+    const pts = buildConnectionPoints(conn);
+    let minDist = Infinity;
+    let insertIdx = conn.waypoints.length;
+    for (let i = 0; i < pts.length - 1; i++) {
+      const ax = pts[i].x, ay = pts[i].y;
+      const bx = pts[i + 1].x, by = pts[i + 1].y;
+      const mx = (ax + bx) / 2, my = (ay + by) / 2;
+      const d = Math.hypot(world.x - mx, world.y - my);
+      if (d < minDist) { minDist = d; insertIdx = i; }
+    }
+
+    const newWaypoints = [...conn.waypoints];
+    newWaypoints.splice(insertIdx, 0, { x: world.x, y: world.y });
+    updateAudioConnectionWaypoints(connId, newWaypoints);
+  }, [connections, viewport, updateAudioConnectionWaypoints]);
+
+  // Build the sequence of points for a connection (start → waypoints → end)
+  function buildConnectionPoints(conn: AudioConnection): Array<{ x: number; y: number }> {
+    const src = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+    const tgt = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+    if (!src || !tgt) return [];
+    return [src, ...conn.waypoints, tgt];
+  }
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if ((e.key === 'Delete' || e.key === 'Backspace') && selectedConnectionId && !editingNodeId) {
+      removeAudioConnection(selectedConnectionId);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+    }
+    if (e.key === 'Escape') {
+      setPendingSource(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+      setStereoPrompt(null);
+      setEditingNodeId(null);
+    }
+  }, [selectedConnectionId, editingNodeId, removeAudioConnection]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Focus edit input when it appears
+  useEffect(() => {
+    if (editingNodeId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingNodeId]);
+
+  const handleFitAll = useCallback(() => {
+    const cards: Array<{ x: number; y: number; width: number; height: number }> = [];
+
+    for (const entry of audioRowEntries) {
+      const pos = getPosition(entry.instanceId, entry.defaultX, entry.defaultY);
+      cards.push({ x: pos.x, y: pos.y, width: CARD_WIDTH, height: CARD_HEIGHT });
+    }
+
+    const numAudio = audioRows.length;
+    for (const node of virtualNodes) {
+      const isGuitar = node.nodeType === 'guitar_input';
+      const fallbackX = isGuitar ? DEFAULT_GUITAR_X(numAudio) : DEFAULT_AMP_X;
+      const pos = getPosition(node.instanceId, fallbackX, DEFAULT_CENTER_Y);
+      cards.push({ x: pos.x, y: pos.y, width: VIRTUAL_NODE_WIDTH, height: VIRTUAL_NODE_HEIGHT });
+    }
+
+    if (cards.length === 0) return;
+    const bbox = calculateBoundingBox(cards);
+    viewport.fitAll(bbox, stageDims.width, stageDims.height);
+  }, [audioRowEntries, virtualNodes, getPosition, audioRows.length, viewport, stageDims]);
+
+  const pendingSourcePos = pendingSource ? portPositions.get(pendingSource.compositeKey) : null;
+
+  const numAudio = audioRows.length;
+
+  if (rows.length === 0) {
+    return (
+      <div className="workbench__canvas-placeholder">
+        Your workbench is empty. Add products from the catalog views.
+      </div>
+    );
+  }
+
+  if (audioRows.length === 0 && virtualNodes.length === 0) {
+    return (
+      <div className="workbench__canvas-placeholder">
+        No items with audio connections in this workbench.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <CanvasBase
+        scale={viewport.scale}
+        offsetX={viewport.offsetX}
+        offsetY={viewport.offsetY}
+        onWheel={viewport.handleWheel}
+        onTouchMove={viewport.handleTouchMove}
+        onTouchEnd={viewport.handleTouchEnd}
+        onStageDragEnd={viewport.handleStageDragEnd}
+        onStageClick={handleStageClick}
+        onStageMouseMove={handleStageMouseMove}
+        onDimensionsChange={handleDimensionsChange}
+      >
+        {/* Connection lines */}
+        {connections.map((conn) => {
+          const sourcePos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+          const targetPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+          if (!sourcePos || !targetPos) return null;
+
+          const validation = connectionValidations.get(conn.id) ?? { status: 'valid' as const, warnings: [] };
+          const isAcknowledged = (conn.acknowledgedWarnings?.length ?? 0) > 0 &&
+            validation.warnings.every(w => conn.acknowledgedWarnings?.includes(w.key));
+
+          return (
+            <ConnectionLine
+              key={conn.id}
+              sourceX={sourcePos.x}
+              sourceY={sourcePos.y}
+              targetX={targetPos.x}
+              targetY={targetPos.y}
+              status={validation.status}
+              acknowledged={isAcknowledged}
+              selected={selectedConnectionId === conn.id}
+              waypoints={conn.waypoints}
+              onClick={() => handleConnectionClick(conn.id)}
+              onDblClick={(e) => handleConnectionDblClick(conn.id, e)}
+            />
+          );
+        })}
+
+        {/* Waypoint circles for selected connection */}
+        {selectedConnectionId && (() => {
+          const conn = connections.find(c => c.id === selectedConnectionId);
+          if (!conn || conn.waypoints.length === 0) return null;
+          return conn.waypoints.map((wp, idx) => (
+            <Circle
+              key={`wp-${conn.id}-${idx}`}
+              x={wp.x}
+              y={wp.y}
+              radius={5}
+              fill="#d4a55a"
+              stroke="#fff"
+              strokeWidth={1}
+              draggable
+              onDragEnd={(e: Konva.KonvaEventObject<DragEvent>) => {
+                const newWaypoints = [...conn.waypoints];
+                newWaypoints[idx] = { x: e.target.x(), y: e.target.y() };
+                updateAudioConnectionWaypoints(conn.id, newWaypoints);
+              }}
+              onDblClick={() => {
+                const newWaypoints = conn.waypoints.filter((_, i) => i !== idx);
+                updateAudioConnectionWaypoints(conn.id, newWaypoints);
+              }}
+              onDblTap={() => {
+                const newWaypoints = conn.waypoints.filter((_, i) => i !== idx);
+                updateAudioConnectionWaypoints(conn.id, newWaypoints);
+              }}
+            />
+          ));
+        })()}
+
+        {/* Preview line while creating a connection */}
+        {pendingSource && pendingSourcePos && mousePos && (
+          <ConnectionLine
+            sourceX={pendingSourcePos.x}
+            sourceY={pendingSourcePos.y}
+            targetX={mousePos.x}
+            targetY={mousePos.y}
+            status="valid"
+          />
+        )}
+
+        {/* Product cards with audio port dots */}
+        {audioRowEntries.map((entry) => {
+          const pos = getPosition(entry.instanceId, entry.defaultX, entry.defaultY);
+          const inputJacks = getAudioInputJacks(entry.row);
+          const outputJacks = getAudioOutputJacks(entry.row);
+
+          return (
+            <ProductCard
+              key={entry.instanceId}
+              productType={entry.row.product_type}
+              manufacturer={entry.row.manufacturer}
+              model={entry.row.model}
+              x={pos.x}
+              y={pos.y}
+              onDragEnd={(x, y) => handleDragEnd(entry.instanceId, x, y)}
+            >
+              {/* Output jacks — left side (x ≈ 2) */}
+              {outputJacks.map((jack, i) => {
+                const key = portKey(entry.instanceId, jack.id);
+                const signalMode = getSignalMode(jack, entry.row);
+                return (
+                  <PortDot
+                    key={key}
+                    x={2}
+                    y={PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.id}
+                    label={jack.jack_name ?? (signalMode === 'stereo' ? 'Out (L/R)' : 'Out')}
+                    direction="output"
+                    color={pendingSource?.compositeKey === key ? '#fff' : '#6aaa6a'}
+                    onClick={() => handlePortClick(entry.instanceId, jack.id, 'output')}
+                  />
+                );
+              })}
+
+              {/* Input jacks — right side (x ≈ CARD_WIDTH - 2) */}
+              {inputJacks.map((jack, i) => {
+                const key = portKey(entry.instanceId, jack.id);
+                const signalMode = getSignalMode(jack, entry.row);
+                return (
+                  <PortDot
+                    key={key}
+                    x={CARD_WIDTH - 2}
+                    y={PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.id}
+                    label={jack.jack_name ?? (signalMode === 'stereo' ? 'In (L/R)' : 'In')}
+                    direction="input"
+                    color={pendingSource?.compositeKey === key ? '#fff' : '#6a6aaa'}
+                    onClick={() => handlePortClick(entry.instanceId, jack.id, 'input')}
+                  />
+                );
+              })}
+            </ProductCard>
+          );
+        })}
+
+        {/* Virtual node cards */}
+        {virtualNodes.map((node) => {
+          const isGuitar = node.nodeType === 'guitar_input';
+          const fallbackX = isGuitar ? DEFAULT_GUITAR_X(numAudio) : DEFAULT_AMP_X;
+          const pos = getPosition(node.instanceId, fallbackX, DEFAULT_CENTER_Y);
+          const portX = isGuitar ? 2 : VIRTUAL_NODE_WIDTH - 2;
+          const portDirection = isGuitar ? 'output' : 'input';
+          const portKey_ = portKey(node.instanceId, node.virtualJackId);
+
+          return (
+            <Group
+              key={node.instanceId}
+              x={pos.x}
+              y={pos.y}
+              draggable
+              onDragEnd={(e: Konva.KonvaEventObject<DragEvent>) => {
+                handleDragEnd(node.instanceId, e.target.x(), e.target.y());
+              }}
+            >
+              <Rect
+                width={VIRTUAL_NODE_WIDTH}
+                height={VIRTUAL_NODE_HEIGHT}
+                fill="#1a2a2a"
+                stroke="#3a7070"
+                strokeWidth={1}
+                cornerRadius={4}
+              />
+              <Text
+                x={8}
+                y={10}
+                width={VIRTUAL_NODE_WIDTH - 16}
+                text={node.label}
+                fontSize={12}
+                fontFamily="'SF Mono', 'Fira Code', monospace"
+                fill="#6adada"
+                align="center"
+                onDblClick={() => {
+                  setEditingNodeId(node.instanceId);
+                  setEditingNodeLabel(node.label);
+                }}
+                onDblTap={() => {
+                  setEditingNodeId(node.instanceId);
+                  setEditingNodeLabel(node.label);
+                }}
+              />
+              <Text
+                x={8}
+                y={28}
+                width={VIRTUAL_NODE_WIDTH - 16}
+                text={node.connectorType}
+                fontSize={9}
+                fontFamily="monospace"
+                fill="#555"
+                align="center"
+                listening={false}
+              />
+              {/* Port dot */}
+              <Circle
+                x={portX}
+                y={VIRTUAL_NODE_HEIGHT / 2}
+                radius={6}
+                fill={pendingSource?.compositeKey === portKey_ ? '#fff' : '#6adada'}
+                stroke="#6adada"
+                strokeWidth={1}
+                onClick={() => handlePortClick(node.instanceId, node.virtualJackId, portDirection)}
+                onTap={() => handlePortClick(node.instanceId, node.virtualJackId, portDirection)}
+              />
+            </Group>
+          );
+        })}
+      </CanvasBase>
+
+      {/* Inline label editor for virtual nodes */}
+      {editingNodeId && (() => {
+        const node = virtualNodes.find(n => n.instanceId === editingNodeId);
+        if (!node) return null;
+        const isGuitar = node.nodeType === 'guitar_input';
+        const fallbackX = isGuitar ? DEFAULT_GUITAR_X(numAudio) : DEFAULT_AMP_X;
+        const pos = getPosition(editingNodeId, fallbackX, DEFAULT_CENTER_Y);
+        const screenPos = viewport.worldToScreen(pos.x + 8, pos.y + 8);
+        return (
+          <input
+            ref={editInputRef}
+            style={{
+              position: 'absolute',
+              left: screenPos.x,
+              top: screenPos.y,
+              width: (VIRTUAL_NODE_WIDTH - 16) * viewport.scale,
+              fontSize: 12 * viewport.scale,
+              background: '#1a2a2a',
+              color: '#6adada',
+              border: '1px solid #3a7070',
+              borderRadius: 2,
+              padding: '2px 4px',
+            }}
+            value={editingNodeLabel}
+            onChange={e => setEditingNodeLabel(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === 'Escape') {
+                if (e.key === 'Enter' && editingNodeLabel.trim()) {
+                  const updatedNodes = virtualNodes.map(n =>
+                    n.instanceId === editingNodeId
+                      ? { ...n, label: editingNodeLabel.trim() }
+                      : n,
+                  );
+                  setVirtualNodes(updatedNodes);
+                }
+                setEditingNodeId(null);
+              }
+            }}
+            onBlur={() => {
+              if (editingNodeLabel.trim()) {
+                const updatedNodes = virtualNodes.map(n =>
+                  n.instanceId === editingNodeId
+                    ? { ...n, label: editingNodeLabel.trim() }
+                    : n,
+                );
+                setVirtualNodes(updatedNodes);
+              }
+              setEditingNodeId(null);
+            }}
+          />
+        );
+      })()}
+
+      {/* Stereo pair prompt */}
+      {stereoPrompt && (
+        <div
+          className="workbench__audio-prompt"
+          style={{ position: 'absolute', left: stereoPrompt.x, top: stereoPrompt.y }}
+        >
+          <span className="workbench__audio-prompt-msg">Connect as stereo pair?</span>
+          <button
+            className="workbench__power-action-btn"
+            onClick={() => handleStereoConfirm(true)}
+          >
+            Yes
+          </button>
+          <button
+            className="workbench__power-action-btn"
+            onClick={() => handleStereoConfirm(false)}
+          >
+            Just this jack
+          </button>
+          <button
+            className="workbench__power-action-btn"
+            onClick={() => setStereoPrompt(null)}
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Canvas action buttons */}
+      <div className="workbench__power-actions">
+        {connections.length > 0 && (
+          <button
+            className="workbench__power-action-btn workbench__power-action-btn--danger"
+            onClick={() => {
+              if (window.confirm(`Clear all ${connections.length} connection${connections.length === 1 ? '' : 's'}?`)) {
+                setAudioConnections([]);
+                setSelectedConnectionId(null);
+                setWarningPopover(null);
+              }
+            }}
+            title="Remove all connections"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Zoom controls */}
+      <ZoomControls
+        scale={viewport.scale}
+        onZoomIn={() => viewport.zoomIn(stageDims.width, stageDims.height)}
+        onZoomOut={() => viewport.zoomOut(stageDims.width, stageDims.height)}
+        onFitAll={handleFitAll}
+      />
+
+      {/* Floating delete button for selected connection */}
+      {selectedConnectionId && (() => {
+        const conn = connections.find(c => c.id === selectedConnectionId);
+        if (!conn) return null;
+        const srcPos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+        const tgtPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+        if (!srcPos || !tgtPos) return null;
+        const midWorld = { x: (srcPos.x + tgtPos.x) / 2, y: (srcPos.y + tgtPos.y) / 2 };
+        const midScreen = viewport.worldToScreen(midWorld.x, midWorld.y);
+        return (
+          <button
+            className="workbench__power-delete-btn"
+            style={{ position: 'absolute', left: midScreen.x, top: midScreen.y }}
+            title="Delete connection"
+            onClick={() => {
+              removeAudioConnection(selectedConnectionId);
+              setSelectedConnectionId(null);
+              setWarningPopover(null);
+            }}
+          >
+            ×
+          </button>
+        );
+      })()}
+
+      {/* Warning popover */}
+      {warningPopover && (() => {
+        const screenPos = viewport.worldToScreen(warningPopover.x, warningPopover.y);
+        return (
+          <div
+            className="workbench__power-popover"
+            style={{ position: 'absolute', left: screenPos.x, top: screenPos.y }}
+          >
+            <div className="workbench__power-popover-warnings">
+              {warningPopover.warnings.map((w) => {
+                const conn = connections.find(c => c.id === warningPopover.connId);
+                const alreadyAcked = conn?.acknowledgedWarnings?.includes(w.key);
+                return (
+                  <div key={w.key} className="workbench__power-popover-warning">
+                    <span>{w.message}</span>
+                    {alreadyAcked ? (
+                      <span className="workbench__power-popover-acked">Acknowledged</span>
+                    ) : (
+                      <button
+                        className="workbench__power-popover-btn"
+                        onClick={() => acknowledgeAudioWarning(warningPopover.connId, w.key)}
+                      >
+                        {w.adapterImplication ? 'I have this adapter' : 'Got it'}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            <button
+              className="workbench__power-popover-btn workbench__power-popover-btn--close"
+              onClick={() => setWarningPopover(null)}
+            >
+              Close
+            </button>
+          </div>
+        );
+      })()}
+    </div>
+  );
+};
+
+export default AudioView;

--- a/apps/web/src/components/Workbench/ConnectionLine.tsx
+++ b/apps/web/src/components/Workbench/ConnectionLine.tsx
@@ -1,4 +1,6 @@
 import { Line } from 'react-konva';
+import Konva from 'konva';
+import { RouteWaypoint } from '../../types/connections';
 
 const STATUS_COLORS = {
   valid: '#6aaa6a',
@@ -16,12 +18,15 @@ interface ConnectionLineProps {
   status: 'valid' | 'warning' | 'error';
   acknowledged?: boolean;
   onClick?: () => void;
+  onDblClick?: (e: Konva.KonvaEventObject<MouseEvent>) => void;
   selected?: boolean;
+  waypoints?: RouteWaypoint[];
 }
 
 /**
- * A connection line between two port dots on the Power canvas.
- * Renders a cubic bezier curve colored by validation status.
+ * A connection line between two port dots on a canvas view.
+ * Renders a cubic bezier curve (no waypoints) or a polyline (with waypoints),
+ * colored by validation status.
  */
 const ConnectionLine = ({
   sourceX,
@@ -31,27 +36,44 @@ const ConnectionLine = ({
   status,
   acknowledged = false,
   onClick,
+  onDblClick,
   selected = false,
+  waypoints,
 }: ConnectionLineProps) => {
   const color = acknowledged ? ACKNOWLEDGED_COLOR : STATUS_COLORS[status];
   const strokeWidth = selected ? 3 : 2;
 
+  const commonProps = {
+    stroke: color,
+    strokeWidth,
+    dash: acknowledged ? [6, 4] : undefined,
+    hitStrokeWidth: 12,
+    onClick,
+    onTap: onClick,
+    onDblClick,
+    onDblTap: onDblClick,
+    shadowColor: selected ? color : undefined,
+    shadowBlur: selected ? 8 : 0,
+    shadowOpacity: selected ? 0.5 : 0,
+  };
+
+  if (waypoints && waypoints.length > 0) {
+    // Polyline through all waypoints
+    const pts: number[] = [sourceX, sourceY];
+    for (const wp of waypoints) {
+      pts.push(wp.x, wp.y);
+    }
+    pts.push(targetX, targetY);
+    return <Line points={pts} {...commonProps} />;
+  }
+
   // Bezier control point offset — curve bows out horizontally
   const dx = Math.abs(targetX - sourceX) * 0.4;
-
   return (
     <Line
       points={[sourceX, sourceY, sourceX + dx, sourceY, targetX - dx, targetY, targetX, targetY]}
-      stroke={color}
-      strokeWidth={strokeWidth}
       bezier
-      dash={acknowledged ? [6, 4] : undefined}
-      hitStrokeWidth={12}
-      onClick={onClick}
-      onTap={onClick}
-      shadowColor={selected ? color : undefined}
-      shadowBlur={selected ? 8 : 0}
-      shadowOpacity={selected ? 0.5 : 0}
+      {...commonProps}
     />
   );
 };

--- a/apps/web/src/components/Workbench/ViewNav.tsx
+++ b/apps/web/src/components/Workbench/ViewNav.tsx
@@ -8,7 +8,7 @@ interface ViewTab {
 
 const VIEW_TABS: ViewTab[] = [
   { key: 'layout', label: 'Layout', enabled: true },
-  { key: 'audio', label: 'Audio', enabled: false },
+  { key: 'audio', label: 'Audio', enabled: true },
   { key: 'power', label: 'Power', enabled: true },
   { key: 'midi', label: 'MIDI', enabled: false },
   { key: 'control', label: 'Control', enabled: false },

--- a/apps/web/src/components/Workbench/index.tsx
+++ b/apps/web/src/components/Workbench/index.tsx
@@ -6,6 +6,7 @@ import InsightsSidebar from './InsightsSidebar';
 import ViewNav, { ViewMode } from './ViewNav';
 import LayoutView from './LayoutView';
 import PowerView from './PowerView';
+import AudioView from './AudioView';
 import './index.scss';
 
 const Workbench = () => {
@@ -111,6 +112,13 @@ const Workbench = () => {
         return (
           <div className="workbench__content workbench__content--canvas">
             <PowerView rows={rows} />
+          </div>
+        );
+
+      case 'audio':
+        return (
+          <div className="workbench__content workbench__content--canvas">
+            <AudioView rows={rows} />
           </div>
         );
 

--- a/apps/web/src/context/WorkbenchContext.tsx
+++ b/apps/web/src/context/WorkbenchContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
+import { AudioConnection, VirtualNode, RouteWaypoint } from '../types/connections';
 
 // --- Types ---
 
@@ -55,6 +56,8 @@ export interface Workbench {
   // Canvas view data:
   viewPositions?: ViewPositions;
   powerConnections?: PowerConnection[];
+  audioConnections?: AudioConnection[];
+  virtualNodes?: VirtualNode[];
   viewportStates?: ViewportStates;
 }
 
@@ -93,6 +96,18 @@ interface WorkbenchContextType {
   removePowerConnection: (connId: string) => void;
   setPowerConnections: (conns: PowerConnection[]) => void;
   acknowledgeWarning: (connId: string, warningKey: string) => void;
+
+  // Audio connections
+  addAudioConnection: (conn: Omit<AudioConnection, 'id'>) => void;
+  removeAudioConnection: (connId: string) => void;
+  setAudioConnections: (conns: AudioConnection[]) => void;
+  acknowledgeAudioWarning: (connId: string, warningKey: string) => void;
+  updateAudioConnectionWaypoints: (connId: string, waypoints: RouteWaypoint[]) => void;
+
+  // Virtual nodes
+  addVirtualNode: (node: VirtualNode) => void;
+  removeVirtualNode: (instanceId: string) => void;
+  setVirtualNodes: (nodes: VirtualNode[]) => void;
 
   // Aggregate counts
   totalItemCount: number;
@@ -364,6 +379,80 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     })));
   }, [updateStore]);
 
+  // --- Audio connections ---
+
+  const addAudioConnection = useCallback((conn: Omit<AudioConnection, 'id'>) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: [...(wb.audioConnections || []), { ...conn, id: generateId() }],
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const removeAudioConnection = useCallback((connId: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: (wb.audioConnections || []).filter(c => c.id !== connId),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const setAudioConnections = useCallback((conns: AudioConnection[]) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: conns,
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const acknowledgeAudioWarning = useCallback((connId: string, warningKey: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: (wb.audioConnections || []).map(c =>
+        c.id === connId
+          ? { ...c, acknowledgedWarnings: [...(c.acknowledgedWarnings || []), warningKey] }
+          : c,
+      ),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const updateAudioConnectionWaypoints = useCallback((connId: string, waypoints: RouteWaypoint[]) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: (wb.audioConnections || []).map(c =>
+        c.id === connId ? { ...c, waypoints } : c,
+      ),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  // --- Virtual nodes ---
+
+  const addVirtualNode = useCallback((node: VirtualNode) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      virtualNodes: [...(wb.virtualNodes || []), node],
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const removeVirtualNode = useCallback((instanceId: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      virtualNodes: (wb.virtualNodes || []).filter(n => n.instanceId !== instanceId),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const setVirtualNodes = useCallback((nodes: VirtualNode[]) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      virtualNodes: nodes,
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
   const totalItemCount = useMemo(
     () => activeWorkbench.items.length,
     [activeWorkbench],
@@ -391,9 +480,17 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
       removePowerConnection,
       setPowerConnections,
       acknowledgeWarning,
+      addAudioConnection,
+      removeAudioConnection,
+      setAudioConnections,
+      acknowledgeAudioWarning,
+      updateAudioConnectionWaypoints,
+      addVirtualNode,
+      removeVirtualNode,
+      setVirtualNodes,
       totalItemCount,
     }),
-    [store.workbenches, activeWorkbench, createWorkbench, renameWorkbench, deleteWorkbench, setActiveWorkbench, addItem, removeItem, removeAllInstances, countInWorkbench, clear, updateViewPosition, updateCardTransform, getViewPositions, getViewportState, updateViewportState, addPowerConnection, removePowerConnection, setPowerConnections, acknowledgeWarning, totalItemCount],
+    [store.workbenches, activeWorkbench, createWorkbench, renameWorkbench, deleteWorkbench, setActiveWorkbench, addItem, removeItem, removeAllInstances, countInWorkbench, clear, updateViewPosition, updateCardTransform, getViewPositions, getViewportState, updateViewportState, addPowerConnection, removePowerConnection, setPowerConnections, acknowledgeWarning, addAudioConnection, removeAudioConnection, setAudioConnections, acknowledgeAudioWarning, updateAudioConnectionWaypoints, addVirtualNode, removeVirtualNode, setVirtualNodes, totalItemCount],
   );
 
   return (

--- a/apps/web/src/types/connections.ts
+++ b/apps/web/src/types/connections.ts
@@ -1,0 +1,51 @@
+export interface RouteWaypoint { x: number; y: number; }
+
+export interface AudioConnection {
+  id: string;
+  sourceJackId: number | string;   // number for real jacks, string for virtual (e.g. 'virtual-jack:guitar-out')
+  targetJackId: number | string;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  orderIndex: number;
+  parallelPathId: string | null;
+  fxLoopGroupId: string | null;
+  signalMode: 'mono' | 'stereo';
+  stereoPairConnectionId: string | null;
+  waypoints: RouteWaypoint[];
+}
+
+export type VirtualNodeType =
+  | 'guitar_input' | 'amp_input' | 'amp_fx_send' | 'amp_fx_return'
+  | 'secondary_amp_input' | 'direct_output' | 'tuner_output';
+
+export interface VirtualNode {
+  instanceId: string;       // e.g. 'virtual:guitar-1'
+  nodeType: VirtualNodeType;
+  label: string;            // user-editable
+  virtualJackId: string;    // e.g. 'virtual-jack:guitar-out'
+  connectorType: string;    // default '1/4" TS'
+}
+
+// Stubs for Phases 3–4 (defined but unused until MIDI/Control views)
+export interface MidiConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  midiChannel: number | null;
+  routesMidiClock: boolean;
+}
+
+export interface ControlConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  controlType: 'expression' | 'aux_switch' | 'cv' | 'other';
+  polarityNormal: boolean;
+}

--- a/apps/web/src/utils/audioUtils.ts
+++ b/apps/web/src/utils/audioUtils.ts
@@ -1,0 +1,129 @@
+import { Jack } from './transformers';
+import { AudioConnection } from '../types/connections';
+import { ConnectionValidation, ConnectionWarning } from './connectionValidation';
+
+// --- Jack filtering helpers ---
+
+export function getAudioInputJacks(row: { jacks: Jack[] }): Jack[] {
+  return row.jacks.filter(j => j.category === 'audio' && j.direction === 'input');
+}
+
+export function getAudioOutputJacks(row: { jacks: Jack[] }): Jack[] {
+  return row.jacks.filter(j => j.category === 'audio' && j.direction === 'output');
+}
+
+export function hasAudioJacks(row: { jacks: Jack[] }): boolean {
+  return row.jacks.some(j => j.category === 'audio');
+}
+
+export function getStereoPartner(jack: Jack, allJacks: Jack[]): Jack | undefined {
+  if (!jack.group_id) return undefined;
+  return allJacks.find(j => j.id !== jack.id && j.group_id === jack.group_id);
+}
+
+// --- Cycle detection ---
+
+export function wouldCreateCycle(
+  sourceInstanceId: string,
+  targetInstanceId: string,
+  existingConnections: AudioConnection[],
+): boolean {
+  // BFS: can we reach sourceInstanceId starting from targetInstanceId?
+  const visited = new Set<string>();
+  const queue: string[] = [targetInstanceId];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current === sourceInstanceId) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    for (const conn of existingConnections) {
+      if (conn.sourceInstanceId === current && !visited.has(conn.targetInstanceId)) {
+        queue.push(conn.targetInstanceId);
+      }
+    }
+  }
+
+  return false;
+}
+
+// --- Connection validation ---
+
+export function validateAudioConnection(
+  sourceJack: { connector_type: string | null; group_id: string | null; impedance_ohms: number | null },
+  targetJack: { connector_type: string | null; group_id: string | null; impedance_ohms: number | null },
+  sourceSignalMode: 'mono' | 'stereo',
+  targetSignalMode: 'mono' | 'stereo',
+  existingConnections: AudioConnection[],
+  sourceInstanceId: string,
+  targetInstanceId: string,
+): ConnectionValidation {
+  const warnings: ConnectionWarning[] = [];
+
+  // Circular connection check (error)
+  if (wouldCreateCycle(sourceInstanceId, targetInstanceId, existingConnections)) {
+    warnings.push({
+      key: 'audio:circular-connection',
+      severity: 'error',
+      message: 'This connection would create a feedback loop in the signal chain.',
+    });
+  }
+
+  // Connector mismatch (warning + adapter)
+  if (
+    sourceJack.connector_type &&
+    targetJack.connector_type &&
+    sourceJack.connector_type !== targetJack.connector_type
+  ) {
+    warnings.push({
+      key: 'audio:connector-mismatch',
+      severity: 'warning',
+      message: `Connector mismatch: ${sourceJack.connector_type} → ${targetJack.connector_type}. An adapter cable is needed.`,
+      adapterImplication: {
+        fromConnectorType: sourceJack.connector_type,
+        toConnectorType: targetJack.connector_type,
+        description: `${sourceJack.connector_type} to ${targetJack.connector_type} adapter`,
+      },
+    });
+  }
+
+  // Mono → stereo
+  if (sourceSignalMode === 'mono' && targetSignalMode === 'stereo') {
+    warnings.push({
+      key: 'audio:mono-to-stereo',
+      severity: 'warning',
+      message: 'Connecting a mono output to a stereo input — the right channel will be silent.',
+    });
+  }
+
+  // Stereo → mono
+  if (sourceSignalMode === 'stereo' && targetSignalMode === 'mono') {
+    warnings.push({
+      key: 'audio:stereo-to-mono',
+      severity: 'warning',
+      message: 'Connecting a stereo output to a mono input — the signal will be summed or the left channel only will pass.',
+    });
+  }
+
+  // Impedance mismatch (target impedance much higher relative to source — loading issue)
+  if (
+    sourceJack.impedance_ohms !== null &&
+    targetJack.impedance_ohms !== null &&
+    targetJack.impedance_ohms / sourceJack.impedance_ohms > 100
+  ) {
+    warnings.push({
+      key: 'audio:impedance-mismatch',
+      severity: 'warning',
+      message: `Impedance mismatch: source ${sourceJack.impedance_ohms}Ω → target ${targetJack.impedance_ohms}Ω. Signal loss may occur.`,
+    });
+  }
+
+  const hasError = warnings.some(w => w.severity === 'error');
+  const hasWarning = warnings.some(w => w.severity === 'warning');
+
+  return {
+    status: hasError ? 'error' : hasWarning ? 'warning' : 'valid',
+    warnings,
+  };
+}

--- a/apps/web/src/utils/transformers.ts
+++ b/apps/web/src/utils/transformers.ts
@@ -24,6 +24,7 @@ export interface Jack {
   is_buffered: boolean | null;
   has_ground_lift: boolean | null;
   has_phase_invert: boolean | null;
+  group_id: string | null;
 }
 
 function transformJack(dto: JackApiResponse): Jack {
@@ -43,6 +44,7 @@ function transformJack(dto: JackApiResponse): Jack {
     is_buffered: dto.isBuffered,
     has_ground_lift: dto.hasGroundLift,
     has_phase_invert: dto.hasPhaseInvert,
+    group_id: dto.groupId,
   };
 }
 

--- a/docs/plans/completed/audio-connections-phase-2.md
+++ b/docs/plans/completed/audio-connections-phase-2.md
@@ -1,0 +1,386 @@
+# Phase 2: Audio Connections View
+
+**Status:** Pending implementation
+**Branch:** `audio-connections-phase-2`
+**Created:** 2026-02-25
+**Design reference:** `docs/plans/connections-and-cabling.md`
+
+## Overview
+
+Implements the Audio Connections canvas view where users wire audio signal flow between pedals and virtual endpoint nodes (guitar input, amp input). Follows the PowerView pattern (`components/Workbench/PowerView.tsx`) but adapts for:
+
+- Right-to-left signal flow (input ports on right side of card, output ports on left)
+- Multiple audio jacks per device stacked vertically
+- Stereo pair handling (two parallel connections for a L/R pair)
+- Cable routing waypoints (bend points on connection lines)
+- Virtual nodes for guitar and amp endpoints
+
+Phase 1 (structured validation types) is complete and merged. `ConnectionWarning` and `ConnectionValidation` live in `utils/connectionValidation.ts` and are ready to use.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `apps/web/src/types/connections.ts` | `AudioConnection`, `VirtualNode`, `VirtualNodeType`, `RouteWaypoint`, plus `MidiConnection`/`ControlConnection` stubs |
+| `apps/web/src/utils/audioUtils.ts` | Jack filtering helpers + `validateAudioConnection()` |
+| `apps/web/src/components/Workbench/AudioView.tsx` | Canvas component (mirrors PowerView structure) |
+| `apps/web/src/__tests__/utils/audioUtils.test.ts` | Unit tests for audioUtils |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `apps/web/src/utils/transformers.ts` | Add `group_id` to `Jack` interface + `transformJack` mapping |
+| `apps/web/src/context/WorkbenchContext.tsx` | Add `audioConnections`/`virtualNodes` to `Workbench` interface + CRUD methods |
+| `apps/web/src/components/Workbench/ConnectionLine.tsx` | Add optional `waypoints` prop + `onDblClick` callback |
+| `apps/web/src/components/Workbench/ViewNav.tsx` | `enabled: false` → `enabled: true` for the `'audio'` tab |
+| `apps/web/src/components/Workbench/index.tsx` | Import `AudioView`, add `case 'audio':` to `renderActiveView()` |
+
+---
+
+## Step-by-Step Implementation
+
+### Step 1: `types/connections.ts`
+
+New file. Defines all connection category types.
+
+```typescript
+export interface RouteWaypoint { x: number; y: number; }
+
+export interface AudioConnection {
+  id: string;
+  sourceJackId: number | string;   // number for real jacks, string for virtual (e.g. 'virtual-jack:guitar-out')
+  targetJackId: number | string;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  orderIndex: number;
+  parallelPathId: string | null;
+  fxLoopGroupId: string | null;
+  signalMode: 'mono' | 'stereo';
+  stereoPairConnectionId: string | null;
+  waypoints: RouteWaypoint[];
+}
+
+export type VirtualNodeType =
+  | 'guitar_input' | 'amp_input' | 'amp_fx_send' | 'amp_fx_return'
+  | 'secondary_amp_input' | 'direct_output' | 'tuner_output';
+
+export interface VirtualNode {
+  instanceId: string;       // e.g. 'virtual:guitar-1'
+  nodeType: VirtualNodeType;
+  label: string;            // user-editable
+  virtualJackId: string;    // e.g. 'virtual-jack:guitar-out'
+  connectorType: string;    // default '1/4" TS'
+}
+
+// Stubs for Phases 3–4 (defined but unused until MIDI/Control views)
+export interface MidiConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  midiChannel: number | null;
+  routesMidiClock: boolean;
+}
+
+export interface ControlConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  controlType: 'expression' | 'aux_switch' | 'cv' | 'other';
+  polarityNormal: boolean;
+}
+```
+
+---
+
+### Step 2: `transformers.ts` — add `group_id`
+
+`JackApiResponse` already has `groupId: string | null` (confirmed in `types/api.ts` line 21). The `Jack` interface and `transformJack` function do not map it yet.
+
+Add to `Jack` interface:
+```typescript
+group_id: string | null;
+```
+
+Add to `transformJack` return object:
+```typescript
+group_id: dto.groupId,
+```
+
+---
+
+### Step 3: `audioUtils.ts`
+
+New file. Provides jack helpers and connection validation.
+
+**Jack filtering helpers** — straightforward filter functions:
+
+```typescript
+export function getAudioInputJacks(row: { jacks: Jack[] }): Jack[]
+  // filter: category === 'audio' && direction === 'input'
+
+export function getAudioOutputJacks(row: { jacks: Jack[] }): Jack[]
+  // filter: category === 'audio' && direction === 'output'
+
+export function hasAudioJacks(row: { jacks: Jack[] }): boolean
+  // true if any jack has category === 'audio'
+
+export function getStereoPartner(jack: Jack, allJacks: Jack[]): Jack | undefined
+  // finds the other jack sharing the same non-null group_id among allJacks
+  // returns undefined if jack.group_id is null or no partner exists
+```
+
+**`validateAudioConnection()`** — returns a `ConnectionValidation`. Rules (keys follow `audio:rule-name` convention):
+
+| Rule key | Severity | Condition | `adapterImplication`? |
+|---|---|---|---|
+| `audio:connector-mismatch` | `warning` | `sourceJack.connector_type !== targetJack.connector_type` (both non-null) | yes |
+| `audio:mono-to-stereo` | `warning` | sourceSignalMode `'mono'` + targetSignalMode `'stereo'` | no |
+| `audio:stereo-to-mono` | `warning` | sourceSignalMode `'stereo'` + targetSignalMode `'mono'` | no |
+| `audio:impedance-mismatch` | `warning` | both jacks have `impedance_ohms`, and `target / source > 100` | no |
+| `audio:circular-connection` | `error` | `wouldCreateCycle()` returns true | no |
+
+`status` is `'error'` if any warning has severity `'error'`, `'warning'` if any warning, else `'valid'`.
+
+**`wouldCreateCycle()`** — internal helper, exported for testing. BFS/DFS over `existingConnections` treating `sourceInstanceId → targetInstanceId` as directed edges. Returns true if `targetInstanceId` can already reach `sourceInstanceId` (i.e., adding the new edge would close a loop).
+
+**Deriving `signalMode`** before calling: AudioView computes `signalMode` from the jack — `'stereo'` if `group_id` is non-null and a stereo partner exists in the same row's jacks, otherwise `'mono'`.
+
+---
+
+### Step 4: `WorkbenchContext.tsx`
+
+**`Workbench` interface additions:**
+```typescript
+audioConnections?: AudioConnection[];
+virtualNodes?: VirtualNode[];
+```
+
+Import `AudioConnection`, `VirtualNode`, `RouteWaypoint` from `../types/connections`.
+
+**`WorkbenchContextType` additions:**
+```typescript
+addAudioConnection: (conn: Omit<AudioConnection, 'id'>) => void;
+removeAudioConnection: (connId: string) => void;
+setAudioConnections: (conns: AudioConnection[]) => void;
+acknowledgeAudioWarning: (connId: string, warningKey: string) => void;
+updateAudioConnectionWaypoints: (connId: string, waypoints: RouteWaypoint[]) => void;
+addVirtualNode: (node: VirtualNode) => void;
+removeVirtualNode: (instanceId: string) => void;
+setVirtualNodes: (nodes: VirtualNode[]) => void;
+```
+
+All implementations use the same `updateStore(prev => updateActiveWorkbench(prev, wb => ...))` pattern as the existing power connection methods. Add all new callbacks to the `useMemo` dependency array for `value`.
+
+---
+
+### Step 5: `ConnectionLine.tsx` — waypoints
+
+Add optional props:
+```typescript
+waypoints?: RouteWaypoint[];
+onDblClick?: () => void;
+```
+
+Rendering logic:
+- **No waypoints (or empty array):** render existing bezier curve — no change to current behavior
+- **Waypoints present:** render as a Konva `Line` with `points` array built by flattening start → each waypoint → end: `[sx, sy, wp0.x, wp0.y, ..., tx, ty]`. No `bezier` prop on polyline variant.
+- Wire `onDblClick` to both `onDblClick` and `onDblTap` on the Konva Line element (both variants).
+
+---
+
+### Step 6: `AudioView.tsx`
+
+Canvas component following the PowerView structure. Key differences from PowerView:
+
+**Signal flow direction:** right-to-left.
+- Output ports (send audio out of device): positioned at `x ≈ 2` (left side of card)
+- Input ports (receive audio into device): positioned at `x ≈ CARD_WIDTH - 2` (right side of card)
+- Port vertical spacing: `PORT_SPACING = 18` (same constant as PowerView)
+
+**Default positions (first render, no saved positions):**
+```
+guitar virtual node: x = CANVAS_WIDTH - VIRTUAL_NODE_WIDTH - 40, y = center
+items with audio jacks: spread horizontally right-to-left, 200px spacing
+amp virtual node: x = 40, y = center
+```
+
+**Virtual node cards** — simple Konva `Group` (not `ProductCard`):
+- Rounded rect with a distinct muted-teal background color
+- Label text (user-editable: dblclick → small HTML `<input>` overlay positioned via `viewport.worldToScreen`)
+- Single port dot (guitar node: output on left; amp node: input on right)
+- Draggable; position saved under their `instanceId` using `updateViewPosition(VIEW_KEY, ...)`
+
+**Auto-init virtual nodes:**
+```typescript
+useEffect(() => {
+  if (!activeWorkbench.virtualNodes || activeWorkbench.virtualNodes.length === 0) {
+    setVirtualNodes([
+      { instanceId: 'virtual:guitar-1', nodeType: 'guitar_input', label: 'Guitar',
+        virtualJackId: 'virtual-jack:guitar-out', connectorType: '1/4" TS' },
+      { instanceId: 'virtual:amp-1', nodeType: 'amp_input', label: 'Amp',
+        virtualJackId: 'virtual-jack:amp-in', connectorType: '1/4" TS' },
+    ]);
+  }
+}, []);
+```
+
+**Port key** — accepts `jackId: number | string` (toString for both):
+```typescript
+function portKey(instanceId: string, jackId: number | string): string {
+  return `${instanceId}:${jackId}`;
+}
+```
+
+**Pending connection state:**
+```typescript
+interface PendingConnection {
+  jackId: number | string;
+  instanceId: string;
+  compositeKey: string;
+  direction: 'output' | 'input';
+}
+```
+
+**Connection creation flow:**
+1. Click output port → `setPendingSource`
+2. Click input port → check if both jacks have `group_id` → show stereo pair prompt OR create directly
+3. ESC cancels pending
+
+**Stereo pair prompt** — HTML overlay (absolute positioned), appears after selecting source and target:
+- "Connect as stereo pair?" with [Yes] and [Just this jack] buttons
+- "Yes": create primary connection (signalMode `'stereo'`) + find stereo partners via `getStereoPartner()` → create second connection with `stereoPairConnectionId = primaryId`
+- "Just this jack": single connection, `stereoPairConnectionId = null`, `signalMode = 'mono'`
+- If either jack has no `group_id`: skip prompt entirely
+
+**Waypoint interaction:**
+- **Add:** dblclick on `ConnectionLine` (via `onDblClick`) → get Konva stage pointer position → `viewport.screenToWorld()` → insert new waypoint at nearest segment index → `updateAudioConnectionWaypoints`
+- **Move:** when connection selected, render draggable Konva `Circle` at each waypoint; `onDragEnd` updates waypoints array
+- **Remove:** dblclick on waypoint circle → remove that index → `updateAudioConnectionWaypoints`
+
+**Warning popover:** same HTML overlay structure as PowerView's popover. Uses `acknowledgeAudioWarning`.
+
+**Toolbar:** zoom controls (`ZoomControls` component, same as PowerView) + fit-all + "Clear all" button (with `window.confirm`).
+
+**Empty state:**
+```
+"No items with audio connections in this workbench."
+```
+Shown when workbench has no rows with audio jacks (and after virtual nodes have been set, which always exist).
+
+**VIEW_KEY:** `'audio'` — all `updateViewPosition` / `getViewPositions` / `updateViewportState` calls use this key.
+
+---
+
+### Step 7: `ViewNav.tsx`
+
+Change:
+```typescript
+{ key: 'audio', label: 'Audio', enabled: false },
+```
+to:
+```typescript
+{ key: 'audio', label: 'Audio', enabled: true },
+```
+
+---
+
+### Step 8: `Workbench/index.tsx`
+
+Add import:
+```typescript
+import AudioView from './AudioView';
+```
+
+Add case to `renderActiveView()` switch:
+```typescript
+case 'audio':
+  return (
+    <div className="workbench__content workbench__content--canvas">
+      <AudioView rows={rows} />
+    </div>
+  );
+```
+
+---
+
+### Step 9: `audioUtils.test.ts`
+
+New file at `apps/web/src/__tests__/utils/audioUtils.test.ts`.
+
+Test cases (must pass with 100% coverage threshold):
+
+| Test | Description |
+|---|---|
+| `getAudioInputJacks` | returns only `category='audio' direction='input'` jacks |
+| `getAudioOutputJacks` | returns only `category='audio' direction='output'` jacks |
+| `hasAudioJacks` | false for power-only row; true for row with audio jacks |
+| `getStereoPartner` | returns partner jack with same group_id; undefined if no group_id |
+| `getStereoPartner` | undefined if group_id set but no matching partner |
+| `validateAudioConnection` — valid | status `'valid'`, no warnings |
+| `validateAudioConnection` — connector mismatch | warning with `adapterImplication` |
+| `validateAudioConnection` — mono→stereo | warning, no `adapterImplication` |
+| `validateAudioConnection` — stereo→mono | warning, no `adapterImplication` |
+| `validateAudioConnection` — impedance mismatch | warning when both jacks have `impedance_ohms` |
+| `validateAudioConnection` — null connector types | no connector-mismatch warning |
+| `wouldCreateCycle` | false for new unconnected items |
+| `wouldCreateCycle` | true when adding connection would close a loop |
+
+---
+
+## Port Layout Reference
+
+```
+AudioView card (right-to-left signal flow):
+
+  RIGHT SIDE (x = CARD_WIDTH - 2)     LEFT SIDE (x = 2)
+  ┌──────────────────────────────────────────────────┐
+  │  [In 1] ●                         ● [Out 1]      │
+  │  [In 2] ●                         ● [Out 2]      │
+  └──────────────────────────────────────────────────┘
+
+Virtual node — Guitar (right side of canvas):
+  ┌────────────┐
+  │   Guitar   │ ● output (left)
+  └────────────┘
+
+Virtual node — Amp (left side of canvas):
+         input ● ┌────────────┐
+                  │    Amp     │
+                  └────────────┘
+```
+
+---
+
+## Verification Checklist
+
+1. `npm run web:test` — all tests pass including new audioUtils tests
+2. `npm run web:build` — compiles cleanly (no TypeScript errors)
+3. Manual: Workbench → Audio tab is now clickable (not greyed out)
+4. Manual: items with audio jacks appear on canvas with L/R port dots
+5. Manual: guitar and amp virtual nodes appear automatically
+6. Manual: click output port → preview line follows mouse → click input port → connection created
+7. Manual: stereo jack pair triggers stereo pair prompt
+8. Manual: connection warning popover appears; acknowledge button works
+9. Manual: double-click connection line → waypoint added, draggable, double-click to remove
+10. Manual: ESC cancels pending; Delete/Backspace removes selected connection
+11. Manual: fit-all button centers all items on canvas
+12. Manual: drag virtual node → position saved, survives page refresh
+
+---
+
+## Key Decisions / Open Questions
+
+- **Virtual jack IDs as strings:** `sourceJackId`/`targetJackId` are typed as `number | string` in `AudioConnection` to handle virtual nodes (`'virtual-jack:guitar-out'`). The `portKey` function accepts `number | string`. This differs from `PowerConnection` which is always `number`.
+- **Virtual nodes always auto-created:** On first mount, guitar + amp nodes are inserted if not already present. User can rename labels; removing virtual nodes is not exposed in the UI in Phase 2.
+- **`MidiConnection` and `ControlConnection`:** defined as stubs in `types/connections.ts` for Phase 3/4; not wired into context or views yet.
+- **No shopping list integration in Phase 2:** cable type derivation (from connector types + signal mode) is deferred to the unified shopping list phase.

--- a/docs/plans/todo.md
+++ b/docs/plans/todo.md
@@ -6,8 +6,8 @@
 
 ## 2. Connections & Cabling (design: `docs/plans/connections-and-cabling.md`)
 
-- [ ] **Structured validation types** — Shared `ConnectionWarning`/`ConnectionValidation` types; migrate `powerUtils.ts` to use them
-- [ ] **Audio connections view** — Signal chain canvas (right-to-left), virtual nodes, stereo pairs, cable routing waypoints
+- [x] **Structured validation types** — Shared `ConnectionWarning`/`ConnectionValidation` types; migrate `powerUtils.ts` to use them (plan: `docs/plans/completed/connections-phase-1-validation-types.md`)
+- [x] **Audio connections view** — Signal chain canvas (right-to-left), virtual nodes, stereo pairs, cable routing waypoints (plan: `docs/plans/completed/audio-connections-phase-2.md`)
 - [ ] **MIDI connections view** — Chain/hub topology, channel assignment, TRS-A/B detection
 - [ ] **Control connections view** — Expression, aux switch, CV connections with polarity validation
 - [ ] **Unified shopping list** — Cables/adapters as rows in List tab alongside products, length estimation from waypoints


### PR DESCRIPTION
## Summary

- **`types/connections.ts`** — `AudioConnection`, `VirtualNode`, `RouteWaypoint`, plus `MidiConnection`/`ControlConnection` stubs for Phases 3–4
- **`utils/audioUtils.ts`** — `getAudioInputJacks`, `getAudioOutputJacks`, `hasAudioJacks`, `getStereoPartner`, `wouldCreateCycle`, `validateAudioConnection`
- **`components/Workbench/AudioView.tsx`** — right-to-left signal chain canvas with virtual guitar/amp nodes, stereo pair prompts, waypoint editing, warning popovers, zoom controls
- **`__tests__/utils/audioUtils.test.ts`** — 23 tests covering all helpers and validation rules
- **`transformers.ts`** — `group_id` added to `Jack` interface and `transformJack` mapping
- **`WorkbenchContext.tsx`** — `audioConnections`, `virtualNodes`, 8 new CRUD methods
- **`ConnectionLine.tsx`** — optional `waypoints` prop (polyline mode) and typed `onDblClick` event prop
- **`ViewNav.tsx`** — Audio tab enabled
- **`Workbench/index.tsx`** — `case 'audio':` wired in
- Plan moved to `docs/plans/completed/`, todo items checked off

## Test plan

- [x] `npm run web:test` — 42 tests pass
- [x] `npm run web:build` — clean compile
- [x] Manual: Audio tab clickable in Workbench nav
- [x] Manual: Items with audio jacks appear with L/R port dots
- [x] Manual: Guitar + Amp virtual nodes auto-appear
- [x] Manual: Click output → preview → click input → connection created
- [ ] Manual: Stereo jack pair triggers stereo pair prompt
- [ ] Manual: Warning popover + acknowledge button works
- [x] Manual: Double-click connection line → waypoint added, draggable, double-click removes
- [x] Manual: ESC cancels pending; Delete removes selected connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)