### PR TITLE
Phase 2 (revised): Audio connections view

### DIFF
--- a/apps/web/src/__tests__/utils/audioUtils.test.ts
+++ b/apps/web/src/__tests__/utils/audioUtils.test.ts
@@ -1,0 +1,327 @@
+import {
+  getAudioInputJacks,
+  getAudioOutputJacks,
+  hasAudioJacks,
+  getStereoPartner,
+  validateAudioConnection,
+  wouldCreateCycle,
+} from '../../utils/audioUtils';
+import { Jack } from '../../utils/transformers';
+import { AudioConnection } from '../../types/connections';
+
+// --- Helpers ---
+
+function makeJack(overrides: Partial<Jack> = {}): Jack {
+  return {
+    id: 1,
+    category: 'audio',
+    direction: 'input',
+    jack_name: null,
+    position: null,
+    connector_type: '1/4" TS',
+    impedance_ohms: null,
+    voltage: null,
+    current_ma: null,
+    polarity: null,
+    function_desc: null,
+    is_isolated: null,
+    is_buffered: null,
+    has_ground_lift: null,
+    has_phase_invert: null,
+    group_id: null,
+    ...overrides,
+  };
+}
+
+function makeConn(overrides: Partial<AudioConnection> = {}): AudioConnection {
+  return {
+    id: 'conn-1',
+    sourceJackId: 1,
+    targetJackId: 2,
+    sourceInstanceId: 'inst-a',
+    targetInstanceId: 'inst-b',
+    orderIndex: 0,
+    parallelPathId: null,
+    fxLoopGroupId: null,
+    signalMode: 'mono',
+    stereoPairConnectionId: null,
+    waypoints: [],
+    ...overrides,
+  };
+}
+
+// --- getAudioInputJacks ---
+
+describe('getAudioInputJacks', () => {
+  it('returns only audio input jacks', () => {
+    const jacks = [
+      makeJack({ id: 1, category: 'audio', direction: 'input' }),
+      makeJack({ id: 2, category: 'audio', direction: 'output' }),
+      makeJack({ id: 3, category: 'power', direction: 'input' }),
+    ];
+    expect(getAudioInputJacks({ jacks })).toEqual([jacks[0]]);
+  });
+
+  it('returns empty array when no audio inputs', () => {
+    const jacks = [makeJack({ category: 'power', direction: 'input' })];
+    expect(getAudioInputJacks({ jacks })).toHaveLength(0);
+  });
+});
+
+// --- getAudioOutputJacks ---
+
+describe('getAudioOutputJacks', () => {
+  it('returns only audio output jacks', () => {
+    const jacks = [
+      makeJack({ id: 1, category: 'audio', direction: 'input' }),
+      makeJack({ id: 2, category: 'audio', direction: 'output' }),
+      makeJack({ id: 3, category: 'midi', direction: 'output' }),
+    ];
+    expect(getAudioOutputJacks({ jacks })).toEqual([jacks[1]]);
+  });
+
+  it('returns empty array when no audio outputs', () => {
+    expect(getAudioOutputJacks({ jacks: [] })).toHaveLength(0);
+  });
+});
+
+// --- hasAudioJacks ---
+
+describe('hasAudioJacks', () => {
+  it('returns false for power-only rows', () => {
+    const jacks = [makeJack({ category: 'power', direction: 'input' })];
+    expect(hasAudioJacks({ jacks })).toBe(false);
+  });
+
+  it('returns true for rows with at least one audio jack', () => {
+    const jacks = [
+      makeJack({ category: 'power', direction: 'input' }),
+      makeJack({ category: 'audio', direction: 'input' }),
+    ];
+    expect(hasAudioJacks({ jacks })).toBe(true);
+  });
+
+  it('returns false for empty jacks array', () => {
+    expect(hasAudioJacks({ jacks: [] })).toBe(false);
+  });
+});
+
+// --- getStereoPartner ---
+
+describe('getStereoPartner', () => {
+  it('returns undefined when jack has no group_id', () => {
+    const jack = makeJack({ id: 1, group_id: null });
+    const allJacks = [jack, makeJack({ id: 2, group_id: 'stereo-1' })];
+    expect(getStereoPartner(jack, allJacks)).toBeUndefined();
+  });
+
+  it('returns the partner jack sharing the same group_id', () => {
+    const jack = makeJack({ id: 1, group_id: 'stereo-1' });
+    const partner = makeJack({ id: 2, group_id: 'stereo-1' });
+    const unrelated = makeJack({ id: 3, group_id: 'stereo-2' });
+    expect(getStereoPartner(jack, [jack, partner, unrelated])).toBe(partner);
+  });
+
+  it('returns undefined when no other jack has the same group_id', () => {
+    const jack = makeJack({ id: 1, group_id: 'stereo-x' });
+    expect(getStereoPartner(jack, [jack])).toBeUndefined();
+  });
+
+  it('does not return the jack itself', () => {
+    const jack = makeJack({ id: 1, group_id: 'stereo-1' });
+    expect(getStereoPartner(jack, [jack])).toBeUndefined();
+  });
+});
+
+// --- wouldCreateCycle ---
+
+describe('wouldCreateCycle', () => {
+  it('returns false for new unconnected items', () => {
+    expect(wouldCreateCycle('A', 'B', [])).toBe(false);
+  });
+
+  it('returns false when source is not reachable from target', () => {
+    const conns = [makeConn({ sourceInstanceId: 'B', targetInstanceId: 'C' })];
+    expect(wouldCreateCycle('A', 'B', conns)).toBe(false);
+  });
+
+  it('returns true for direct cycle A→B and B→A attempted', () => {
+    const conns = [makeConn({ sourceInstanceId: 'A', targetInstanceId: 'B' })];
+    // Trying to add B→A would create a cycle
+    expect(wouldCreateCycle('B', 'A', conns)).toBe(true);
+  });
+
+  it('returns true for indirect cycle A→B→C and C→A attempted', () => {
+    const conns = [
+      makeConn({ id: '1', sourceInstanceId: 'A', targetInstanceId: 'B' }),
+      makeConn({ id: '2', sourceInstanceId: 'B', targetInstanceId: 'C' }),
+    ];
+    expect(wouldCreateCycle('C', 'A', conns)).toBe(true);
+  });
+
+  it('returns false for non-cyclic chain', () => {
+    const conns = [
+      makeConn({ id: '1', sourceInstanceId: 'A', targetInstanceId: 'B' }),
+      makeConn({ id: '2', sourceInstanceId: 'B', targetInstanceId: 'C' }),
+    ];
+    // Adding A→C is not a cycle
+    expect(wouldCreateCycle('A', 'C', conns)).toBe(false);
+  });
+});
+
+// --- validateAudioConnection ---
+
+const baseSourceJack = { connector_type: '1/4" TS', group_id: null, impedance_ohms: null };
+const baseTargetJack = { connector_type: '1/4" TS', group_id: null, impedance_ohms: null };
+
+describe('validateAudioConnection', () => {
+  it('returns valid status for compatible jacks', () => {
+    const result = validateAudioConnection(
+      baseSourceJack,
+      baseTargetJack,
+      'mono',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('valid');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('returns error for circular connection', () => {
+    const conns = [makeConn({ sourceInstanceId: 'inst-a', targetInstanceId: 'inst-b' })];
+    const result = validateAudioConnection(
+      baseSourceJack,
+      baseTargetJack,
+      'mono',
+      'mono',
+      conns,
+      'inst-b',
+      'inst-a',
+    );
+    expect(result.status).toBe('error');
+    expect(result.warnings[0].key).toBe('audio:circular-connection');
+    expect(result.warnings[0].severity).toBe('error');
+  });
+
+  it('returns warning with adapterImplication for connector mismatch', () => {
+    const result = validateAudioConnection(
+      { ...baseSourceJack, connector_type: '1/4" TS' },
+      { ...baseTargetJack, connector_type: 'XLR' },
+      'mono',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0].key).toBe('audio:connector-mismatch');
+    expect(result.warnings[0].severity).toBe('warning');
+    expect(result.warnings[0].adapterImplication).toMatchObject({
+      fromConnectorType: '1/4" TS',
+      toConnectorType: 'XLR',
+    });
+  });
+
+  it('returns warning for mono to stereo connection', () => {
+    const result = validateAudioConnection(
+      baseSourceJack,
+      baseTargetJack,
+      'mono',
+      'stereo',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0].key).toBe('audio:mono-to-stereo');
+    expect(result.warnings[0].severity).toBe('warning');
+    expect(result.warnings[0].adapterImplication).toBeUndefined();
+  });
+
+  it('returns warning for stereo to mono connection', () => {
+    const result = validateAudioConnection(
+      baseSourceJack,
+      baseTargetJack,
+      'stereo',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0].key).toBe('audio:stereo-to-mono');
+    expect(result.warnings[0].severity).toBe('warning');
+    expect(result.warnings[0].adapterImplication).toBeUndefined();
+  });
+
+  it('returns warning for impedance mismatch (ratio > 100)', () => {
+    const result = validateAudioConnection(
+      { ...baseSourceJack, impedance_ohms: 150 },
+      { ...baseTargetJack, impedance_ohms: 20000 },
+      'mono',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    expect(result.warnings[0].key).toBe('audio:impedance-mismatch');
+    expect(result.warnings[0].severity).toBe('warning');
+  });
+
+  it('does not warn for impedance ratio at or below 100', () => {
+    const result = validateAudioConnection(
+      { ...baseSourceJack, impedance_ohms: 150 },
+      { ...baseTargetJack, impedance_ohms: 15000 },
+      'mono',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('valid');
+  });
+
+  it('handles null connector types gracefully (no connector warning)', () => {
+    const result = validateAudioConnection(
+      { connector_type: null, group_id: null, impedance_ohms: null },
+      { connector_type: null, group_id: null, impedance_ohms: null },
+      'mono',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('valid');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('handles null impedance values gracefully (no impedance warning)', () => {
+    const result = validateAudioConnection(
+      { ...baseSourceJack, impedance_ohms: null },
+      { ...baseTargetJack, impedance_ohms: null },
+      'mono',
+      'mono',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('valid');
+  });
+
+  it('can accumulate multiple warnings', () => {
+    const result = validateAudioConnection(
+      { connector_type: '1/4" TS', group_id: null, impedance_ohms: 150 },
+      { connector_type: 'XLR', group_id: null, impedance_ohms: 20000 },
+      'mono',
+      'stereo',
+      [],
+      'inst-a',
+      'inst-b',
+    );
+    expect(result.status).toBe('warning');
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/src/components/Workbench/AudioView.tsx
+++ b/apps/web/src/components/Workbench/AudioView.tsx
@@ -1,0 +1,1004 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { Group, Rect, Text, Circle } from 'react-konva';
+import Konva from 'konva';
+import { useWorkbench } from '../../context/WorkbenchContext';
+import { AudioConnection, VirtualNode, VirtualNodeType, AudioPlaceholder, VirtualJackSpec } from '../../types/connections';
+import { WorkbenchRow } from './WorkbenchTable';
+import {
+  getAudioInputJacks,
+  getAudioOutputJacks,
+  hasAudioJacks,
+  getStereoPartner,
+  validateAudioConnection,
+} from '../../utils/audioUtils';
+import { ConnectionValidation, ConnectionWarning } from '../../utils/connectionValidation';
+import { Jack } from '../../utils/transformers';
+import { useCanvasViewport } from '../../hooks/useCanvasViewport';
+import { calculateBoundingBox } from '../../utils/canvasUtils';
+import CanvasBase from './CanvasBase';
+import ProductCard, { CARD_WIDTH, CARD_HEIGHT } from './ProductCard';
+import PortDot from './PortDot';
+import ConnectionLine from './ConnectionLine';
+import ZoomControls from './ZoomControls';
+
+const VIEW_KEY = 'audio';
+
+const PORT_SPACING = 18;
+// Ports start just below the card's text content area (type label is at y=44)
+const AUDIO_PORT_START_Y = CARD_HEIGHT - 4;
+const AUDIO_PORT_EXTRA = PORT_SPACING;
+
+const VIRTUAL_NODE_WIDTH = 100;
+const VIRTUAL_NODE_HEIGHT = 48;
+
+const DEFAULT_AMP_X = 40;
+const DEFAULT_ITEM_X_START = 200;
+const DEFAULT_ITEM_X_STEP = 200;
+const DEFAULT_CENTER_Y = 180;
+
+function audioCardHeight(inputCount: number, outputCount: number): number {
+  const portCount = Math.max(inputCount, outputCount);
+  if (portCount <= 1) return CARD_HEIGHT;
+  return CARD_HEIGHT + (portCount - 1) * AUDIO_PORT_EXTRA;
+}
+
+function portKey(instanceId: string, jackId: number | string): string {
+  return `${instanceId}:${jackId}`;
+}
+
+// --- Placeholder presets ---
+
+function generateId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return Date.now().toString(36) + Math.random().toString(36).substring(2);
+}
+
+function makePlaceholderJack(
+  instanceId: string,
+  direction: 'input' | 'output',
+  index: number,
+  label: string,
+  connectorType = '1/4" TS',
+  group_id: string | null = null,
+): VirtualJackSpec {
+  return {
+    virtualJackId: `placeholder:${instanceId}:${direction}-${index}`,
+    direction,
+    connectorType,
+    label,
+    group_id,
+  };
+}
+
+const PLACEHOLDER_PRESETS: Array<{
+  label: string;
+  description: string;
+  build: (instanceId: string) => VirtualJackSpec[];
+}> = [
+  {
+    label: 'Mono pedal',
+    description: '1× TS out, 1× TS in',
+    build: (id) => [
+      makePlaceholderJack(id, 'output', 0, 'Out'),
+      makePlaceholderJack(id, 'input', 0, 'In'),
+    ],
+  },
+  {
+    label: 'Stereo pedal',
+    description: '2× TS out (L/R), 2× TS in (L/R)',
+    build: (id) => {
+      const outGroup = generateId();
+      const inGroup = generateId();
+      return [
+        makePlaceholderJack(id, 'output', 0, 'Out L', '1/4" TS', outGroup),
+        makePlaceholderJack(id, 'output', 1, 'Out R', '1/4" TS', outGroup),
+        makePlaceholderJack(id, 'input', 0, 'In L', '1/4" TS', inGroup),
+        makePlaceholderJack(id, 'input', 1, 'In R', '1/4" TS', inGroup),
+      ];
+    },
+  },
+  {
+    label: 'Mono in / Stereo out',
+    description: '2× TS out (L/R), 1× TS in',
+    build: (id) => {
+      const outGroup = generateId();
+      return [
+        makePlaceholderJack(id, 'output', 0, 'Out L', '1/4" TS', outGroup),
+        makePlaceholderJack(id, 'output', 1, 'Out R', '1/4" TS', outGroup),
+        makePlaceholderJack(id, 'input', 0, 'In'),
+      ];
+    },
+  },
+  {
+    label: 'Mono FX loop',
+    description: '1× TS out, 1× TS in, send + return',
+    build: (id) => [
+      makePlaceholderJack(id, 'output', 0, 'Out'),
+      makePlaceholderJack(id, 'output', 1, 'FX Send'),
+      makePlaceholderJack(id, 'input', 0, 'In'),
+      makePlaceholderJack(id, 'input', 1, 'FX Return'),
+    ],
+  },
+  {
+    label: 'Stereo FX loop',
+    description: '2× TS out, 2× TS in, send + return',
+    build: (id) => {
+      const outGroup = generateId();
+      const inGroup = generateId();
+      return [
+        makePlaceholderJack(id, 'output', 0, 'Out L', '1/4" TS', outGroup),
+        makePlaceholderJack(id, 'output', 1, 'Out R', '1/4" TS', outGroup),
+        makePlaceholderJack(id, 'output', 2, 'FX Send'),
+        makePlaceholderJack(id, 'input', 0, 'In L', '1/4" TS', inGroup),
+        makePlaceholderJack(id, 'input', 1, 'In R', '1/4" TS', inGroup),
+        makePlaceholderJack(id, 'input', 2, 'FX Return'),
+      ];
+    },
+  },
+];
+
+// --- Additional virtual node presets ---
+
+const ADDITIONAL_NODE_PRESETS: Array<{
+  label: string;
+  nodeType: VirtualNodeType;
+  virtualJackId: (n: number) => string;
+  connectorType: string;
+}> = [
+  { label: 'Second Amp',    nodeType: 'secondary_amp_input', virtualJackId: (n) => `virtual-jack:amp2-in-${n}`,    connectorType: '1/4" TS' },
+  { label: 'FRFR / Speaker', nodeType: 'frfr_input',          virtualJackId: (n) => `virtual-jack:frfr-in-${n}`,   connectorType: '1/4" TS' },
+  { label: 'Direct Out (FOH)', nodeType: 'direct_output',     virtualJackId: (n) => `virtual-jack:direct-out-${n}`, connectorType: 'XLR' },
+  { label: 'Tuner Out',     nodeType: 'tuner_output',         virtualJackId: (n) => `virtual-jack:tuner-out-${n}`,  connectorType: '1/4" TS' },
+];
+
+// --- Virtual jack for validation ---
+
+function virtualJackData(connectorType: string) {
+  return { connector_type: connectorType, group_id: null as string | null, impedance_ohms: null as number | null };
+}
+
+// --- Pending connection state ---
+
+interface PendingConnection {
+  jackId: number | string;
+  instanceId: string;
+  compositeKey: string;
+  direction: 'output' | 'input';
+}
+
+interface StereoPrompt {
+  sourceJackId: number | string;
+  sourceInstanceId: string;
+  targetJackId: number | string;
+  targetInstanceId: string;
+  screenX: number;
+  screenY: number;
+}
+
+interface AudioViewProps {
+  rows: WorkbenchRow[];
+}
+
+const AudioView = ({ rows }: AudioViewProps) => {
+  const {
+    getViewPositions,
+    updateViewPosition,
+    addAudioConnection,
+    removeAudioConnection,
+    setAudioConnections,
+    acknowledgeAudioWarning,
+    setVirtualNodes,
+    addVirtualNode,
+    removeVirtualNode,
+    addAudioPlaceholder,
+    removeAudioPlaceholder,
+    updateAudioPlaceholderLabel,
+    activeWorkbench,
+  } = useWorkbench();
+
+  const savedPositions = getViewPositions(VIEW_KEY);
+  const connections: AudioConnection[] = activeWorkbench.audioConnections ?? [];
+  const virtualNodes: VirtualNode[] = activeWorkbench.virtualNodes ?? [];
+  const placeholders: AudioPlaceholder[] = activeWorkbench.audioPlaceholders ?? [];
+
+  const viewport = useCanvasViewport(VIEW_KEY);
+  const [stageDims, setStageDims] = useState({ width: 800, height: 600 });
+  const handleDimensionsChange = useCallback((w: number, h: number) => setStageDims({ width: w, height: h }), []);
+
+  // Auto-init default virtual nodes on first mount
+  useEffect(() => {
+    if (!activeWorkbench.virtualNodes || activeWorkbench.virtualNodes.length === 0) {
+      setVirtualNodes([
+        { instanceId: 'virtual:guitar-1', nodeType: 'guitar_input',  label: 'Guitar', virtualJackId: 'virtual-jack:guitar-out', connectorType: '1/4" TS' },
+        { instanceId: 'virtual:amp-1',    nodeType: 'amp_input',     label: 'Amp',    virtualJackId: 'virtual-jack:amp-in',    connectorType: '1/4" TS' },
+      ]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Interaction state
+  const [pendingSource, setPendingSource] = useState<PendingConnection | null>(null);
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+  const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null); // for placeholders/nodes
+  const [mousePos, setMousePos] = useState<{ x: number; y: number } | null>(null);
+  const [warningPopover, setWarningPopover] = useState<{ connId: string; warnings: ConnectionWarning[]; x: number; y: number } | null>(null);
+  const [stereoPrompt, setStereoPrompt] = useState<StereoPrompt | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingLabel, setEditingLabel] = useState('');
+  const editInputRef = useRef<HTMLInputElement>(null);
+  const [showPlaceholderMenu, setShowPlaceholderMenu] = useState(false);
+  const [showNodeMenu, setShowNodeMenu] = useState(false);
+
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingId]);
+
+  // Rows with audio jacks
+  const audioRows = useMemo(() => rows.filter(hasAudioJacks), [rows]);
+  const missingRows = useMemo(() => rows.filter(r => !hasAudioJacks(r)), [rows]);
+
+  // Jack lookup
+  const jackMap = useMemo(() => {
+    const map = new Map<number, Jack>();
+    for (const row of rows) for (const jack of row.jacks) map.set(jack.id, jack);
+    return map;
+  }, [rows]);
+
+  const rowMap = useMemo(() => {
+    const map = new Map<string, WorkbenchRow>();
+    for (const row of rows) map.set(row.instanceId, row);
+    return map;
+  }, [rows]);
+
+  // Default layout positions for audio rows
+  const audioRowEntries = useMemo(() =>
+    audioRows.map((row, i) => ({
+      instanceId: row.instanceId,
+      row,
+      defaultX: DEFAULT_ITEM_X_START + i * DEFAULT_ITEM_X_STEP,
+      defaultY: DEFAULT_CENTER_Y,
+    })),
+  [audioRows]);
+
+  // Default positions for placeholders (to the right of real items)
+  const placeholderEntries = useMemo(() =>
+    placeholders.map((p, i) => ({
+      placeholder: p,
+      defaultX: DEFAULT_ITEM_X_START + (audioRows.length + i) * DEFAULT_ITEM_X_STEP,
+      defaultY: DEFAULT_CENTER_Y,
+    })),
+  [placeholders, audioRows.length]);
+
+  const getPosition = useCallback((instanceId: string, fallbackX: number, fallbackY: number) =>
+    savedPositions[instanceId] ?? { x: fallbackX, y: fallbackY },
+  [savedPositions]);
+
+  const numAudio = audioRows.length;
+  const numPlaceholders = placeholders.length;
+
+  // Virtual node default positions
+  const getVirtualNodeDefault = useCallback((node: VirtualNode): { x: number; y: number } => {
+    const isSource = node.nodeType === 'guitar_input';
+    if (isSource) {
+      return { x: DEFAULT_ITEM_X_START + (numAudio + numPlaceholders) * DEFAULT_ITEM_X_STEP + 40, y: DEFAULT_CENTER_Y };
+    }
+    return { x: DEFAULT_AMP_X, y: DEFAULT_CENTER_Y };
+  }, [numAudio, numPlaceholders]);
+
+  // Port positions (world coords) keyed by portKey
+  const portPositions = useMemo(() => {
+    const map = new Map<string, { x: number; y: number }>();
+
+    // Real product cards
+    for (const entry of audioRowEntries) {
+      const pos = getPosition(entry.instanceId, entry.defaultX, entry.defaultY);
+      const outputs = getAudioOutputJacks(entry.row);
+      const inputs  = getAudioInputJacks(entry.row);
+      outputs.forEach((jack, i) => map.set(portKey(entry.instanceId, jack.id), {
+        x: pos.x + 2,
+        y: pos.y + AUDIO_PORT_START_Y + i * PORT_SPACING,
+      }));
+      inputs.forEach((jack, i) => map.set(portKey(entry.instanceId, jack.id), {
+        x: pos.x + CARD_WIDTH - 2,
+        y: pos.y + AUDIO_PORT_START_Y + i * PORT_SPACING,
+      }));
+    }
+
+    // Placeholder cards
+    for (const entry of placeholderEntries) {
+      const pos = getPosition(entry.placeholder.instanceId, entry.defaultX, entry.defaultY);
+      const outputs = entry.placeholder.jacks.filter(j => j.direction === 'output');
+      const inputs  = entry.placeholder.jacks.filter(j => j.direction === 'input');
+      const cardH = audioCardHeight(inputs.length, outputs.length);
+      outputs.forEach((jack, i) => map.set(portKey(entry.placeholder.instanceId, jack.virtualJackId), {
+        x: pos.x + 2,
+        y: pos.y + Math.max(0, cardH - CARD_HEIGHT) + AUDIO_PORT_START_Y - Math.max(0, cardH - CARD_HEIGHT) + AUDIO_PORT_START_Y - (AUDIO_PORT_START_Y - (CARD_HEIGHT - 4)) + i * PORT_SPACING,
+      }));
+      inputs.forEach((jack, i) => map.set(portKey(entry.placeholder.instanceId, jack.virtualJackId), {
+        x: pos.x + CARD_WIDTH - 2,
+        y: pos.y + AUDIO_PORT_START_Y + i * PORT_SPACING,
+      }));
+    }
+
+    // Virtual nodes
+    for (const node of virtualNodes) {
+      const def = getVirtualNodeDefault(node);
+      const pos = getPosition(node.instanceId, def.x, def.y);
+      const isSource = node.nodeType === 'guitar_input';
+      map.set(portKey(node.instanceId, node.virtualJackId), {
+        x: isSource ? pos.x + 2 : pos.x + VIRTUAL_NODE_WIDTH - 2,
+        y: pos.y + VIRTUAL_NODE_HEIGHT / 2,
+      });
+    }
+
+    return map;
+  }, [audioRowEntries, placeholderEntries, virtualNodes, getPosition, getVirtualNodeDefault]);
+
+  // Validate connections
+  const connectionValidations = useMemo(() => {
+    const map = new Map<string, ConnectionValidation>();
+    for (const conn of connections) {
+      const srcIsVirtual = typeof conn.sourceJackId === 'string';
+      const tgtIsVirtual = typeof conn.targetJackId === 'string';
+
+      const srcNode = srcIsVirtual ? virtualNodes.find(n => n.virtualJackId === conn.sourceJackId) : null;
+      const tgtNode = tgtIsVirtual ? virtualNodes.find(n => n.virtualJackId === conn.targetJackId) : null;
+
+      // Also check placeholder jacks
+      const findPlaceholderJack = (id: string | number): VirtualJackSpec | undefined => {
+        for (const p of placeholders) {
+          const j = p.jacks.find(j => j.virtualJackId === id);
+          if (j) return j;
+        }
+        return undefined;
+      };
+
+      const srcJack = srcIsVirtual
+        ? (srcNode ? virtualJackData(srcNode.connectorType) : (findPlaceholderJack(conn.sourceJackId) ? virtualJackData(findPlaceholderJack(conn.sourceJackId)!.connectorType) : null))
+        : (jackMap.get(conn.sourceJackId as number) ?? null);
+      const tgtJack = tgtIsVirtual
+        ? (tgtNode ? virtualJackData(tgtNode.connectorType) : (findPlaceholderJack(conn.targetJackId) ? virtualJackData(findPlaceholderJack(conn.targetJackId)!.connectorType) : null))
+        : (jackMap.get(conn.targetJackId as number) ?? null);
+
+      if (srcJack && tgtJack) {
+        map.set(conn.id, validateAudioConnection(
+          srcJack, tgtJack,
+          conn.signalMode, conn.signalMode,
+          connections.filter(c => c.id !== conn.id),
+          conn.sourceInstanceId, conn.targetInstanceId,
+        ));
+      } else {
+        map.set(conn.id, { status: 'valid' as const, warnings: [] });
+      }
+    }
+    return map;
+  }, [connections, virtualNodes, placeholders, jackMap]);
+
+  const handleDragEnd = useCallback((instanceId: string, x: number, y: number) => {
+    updateViewPosition(VIEW_KEY, instanceId, x, y);
+  }, [updateViewPosition]);
+
+  const getSignalMode = useCallback((jack: Jack, row: WorkbenchRow): 'mono' | 'stereo' => {
+    if (!jack.group_id) return 'mono';
+    return getStereoPartner(jack, row.jacks) ? 'stereo' : 'mono';
+  }, []);
+
+  // --- Connection interaction ---
+
+  const handlePortClick = useCallback((instanceId: string, jackId: number | string, direction: 'output' | 'input') => {
+    const key = portKey(instanceId, jackId);
+    setSelectedInstanceId(null);
+
+    if (!pendingSource) {
+      setPendingSource({ jackId, instanceId, compositeKey: key, direction });
+      setMousePos(null);
+      setSelectedConnectionId(null);
+      setWarningPopover(null);
+      setStereoPrompt(null);
+    } else if (pendingSource.compositeKey === key) {
+      setPendingSource(null);
+      setMousePos(null);
+    } else if (pendingSource.direction === direction) {
+      // Same direction — swap pending to new port
+      setPendingSource({ jackId, instanceId, compositeKey: key, direction });
+      setMousePos(null);
+    } else {
+      const sourceJackId = direction === 'input' ? pendingSource.jackId : jackId;
+      const targetJackId = direction === 'input' ? jackId : pendingSource.jackId;
+      const sourceInstanceId = direction === 'input' ? pendingSource.instanceId : instanceId;
+      const targetInstanceId = direction === 'input' ? instanceId : pendingSource.instanceId;
+
+      // Check stereo: both jacks must be real jacks with a stereo partner
+      const srcJack = typeof sourceJackId === 'number' ? jackMap.get(sourceJackId) : null;
+      const tgtJack = typeof targetJackId === 'number' ? jackMap.get(targetJackId) : null;
+      const srcRow = rowMap.get(sourceInstanceId);
+      const tgtRow = rowMap.get(targetInstanceId);
+      const srcHasStereo = srcJack && srcRow && srcJack.group_id !== null && !!getStereoPartner(srcJack, srcRow.jacks);
+      const tgtHasStereo = tgtJack && tgtRow && tgtJack.group_id !== null && !!getStereoPartner(tgtJack, tgtRow.jacks);
+
+      if (srcHasStereo && tgtHasStereo) {
+        const srcPos = portPositions.get(portKey(sourceInstanceId, sourceJackId));
+        const tgtPos = portPositions.get(portKey(targetInstanceId, targetJackId));
+        const midWorld = srcPos && tgtPos ? { x: (srcPos.x + tgtPos.x) / 2, y: (srcPos.y + tgtPos.y) / 2 } : { x: 0, y: 0 };
+        const midScreen = viewport.worldToScreen(midWorld.x, midWorld.y);
+        setStereoPrompt({ sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, screenX: midScreen.x, screenY: midScreen.y - 40 });
+        setPendingSource(null);
+        setMousePos(null);
+      } else {
+        createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'mono', null);
+        setPendingSource(null);
+        setMousePos(null);
+      }
+    }
+  }, [pendingSource, jackMap, rowMap, portPositions, viewport]);
+
+  const createConnection = useCallback((
+    sourceJackId: number | string, sourceInstanceId: string,
+    targetJackId: number | string, targetInstanceId: string,
+    signalMode: 'mono' | 'stereo',
+    stereoPairConnectionId: string | null,
+  ) => {
+    addAudioConnection({
+      sourceJackId, targetJackId, sourceInstanceId, targetInstanceId,
+      orderIndex: connections.length,
+      parallelPathId: null, fxLoopGroupId: null,
+      signalMode, stereoPairConnectionId, waypoints: [],
+    });
+  }, [addAudioConnection, connections.length]);
+
+  const handleStereoConfirm = useCallback((asStereo: boolean) => {
+    if (!stereoPrompt) return;
+    const { sourceJackId, sourceInstanceId, targetJackId, targetInstanceId } = stereoPrompt;
+
+    if (asStereo) {
+      const srcJack = typeof sourceJackId === 'number' ? jackMap.get(sourceJackId) : null;
+      const tgtJack = typeof targetJackId === 'number' ? jackMap.get(targetJackId) : null;
+      const srcRow = rowMap.get(sourceInstanceId);
+      const tgtRow = rowMap.get(targetInstanceId);
+      const srcPartner = srcJack && srcRow ? getStereoPartner(srcJack, srcRow.jacks) : undefined;
+      const tgtPartner = tgtJack && tgtRow ? getStereoPartner(tgtJack, tgtRow.jacks) : undefined;
+
+      createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'stereo', null);
+      if (srcPartner && tgtPartner) {
+        createConnection(srcPartner.id, sourceInstanceId, tgtPartner.id, targetInstanceId, 'stereo', null);
+      }
+    } else {
+      createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'mono', null);
+    }
+    setStereoPrompt(null);
+  }, [stereoPrompt, jackMap, rowMap, createConnection]);
+
+  const handleStageMouseMove = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (!pendingSource) return;
+    const stage = e.target.getStage();
+    if (stage) {
+      const pos = stage.getPointerPosition();
+      if (pos) setMousePos(viewport.screenToWorld(pos.x, pos.y));
+    }
+  }, [pendingSource, viewport]);
+
+  const handleStageClick = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
+    if (e.target === e.target.getStage()) {
+      setPendingSource(null);
+      setSelectedConnectionId(null);
+      setSelectedInstanceId(null);
+      setWarningPopover(null);
+      setStereoPrompt(null);
+      setShowPlaceholderMenu(false);
+      setShowNodeMenu(false);
+    }
+  }, []);
+
+  const handleConnectionClick = useCallback((connId: string) => {
+    const validation = connectionValidations.get(connId);
+    const conn = connections.find(c => c.id === connId);
+    if (validation && validation.warnings.length > 0 && conn) {
+      const srcPos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+      const tgtPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+      if (srcPos && tgtPos) {
+        setWarningPopover({ connId, warnings: validation.warnings, x: (srcPos.x + tgtPos.x) / 2, y: (srcPos.y + tgtPos.y) / 2 - 30 });
+      }
+    }
+    setSelectedConnectionId(connId);
+    setSelectedInstanceId(null);
+    setPendingSource(null);
+    setStereoPrompt(null);
+  }, [connectionValidations, connections, portPositions]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    const tag = (e.target as HTMLElement)?.tagName;
+    if (tag === 'INPUT') return;
+
+    if (e.key === 'Escape') {
+      setPendingSource(null);
+      setSelectedConnectionId(null);
+      setSelectedInstanceId(null);
+      setWarningPopover(null);
+      setStereoPrompt(null);
+      setShowPlaceholderMenu(false);
+      setShowNodeMenu(false);
+    }
+
+    if (e.key === 'Delete' || e.key === 'Backspace') {
+      if (selectedConnectionId) {
+        removeAudioConnection(selectedConnectionId);
+        setSelectedConnectionId(null);
+        setWarningPopover(null);
+      } else if (selectedInstanceId) {
+        // Remove placeholder or additional virtual node (not the default guitar/amp)
+        const isPlaceholder = placeholders.some(p => p.instanceId === selectedInstanceId);
+        const isDefaultNode = selectedInstanceId === 'virtual:guitar-1' || selectedInstanceId === 'virtual:amp-1';
+
+        if (isPlaceholder) {
+          removeAudioPlaceholder(selectedInstanceId);
+          setAudioConnections(connections.filter(c =>
+            c.sourceInstanceId !== selectedInstanceId && c.targetInstanceId !== selectedInstanceId,
+          ));
+          setSelectedInstanceId(null);
+        } else if (!isDefaultNode) {
+          removeVirtualNode(selectedInstanceId);
+          setAudioConnections(connections.filter(c =>
+            c.sourceInstanceId !== selectedInstanceId && c.targetInstanceId !== selectedInstanceId,
+          ));
+          setSelectedInstanceId(null);
+        }
+      }
+    }
+  }, [selectedConnectionId, selectedInstanceId, connections, placeholders, removeAudioConnection, removeAudioPlaceholder, removeVirtualNode, setAudioConnections]);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Label editing commit
+  const commitLabel = useCallback((id: string, label: string) => {
+    if (!label.trim()) return;
+    const isPlaceholder = placeholders.some(p => p.instanceId === id);
+    if (isPlaceholder) {
+      updateAudioPlaceholderLabel(id, label.trim());
+    } else {
+      // Virtual node rename — update the node's label
+      const updatedNodes = virtualNodes.map(n => n.instanceId === id ? { ...n, label: label.trim() } : n);
+      setVirtualNodes(updatedNodes);
+    }
+    setEditingId(null);
+  }, [placeholders, virtualNodes, updateAudioPlaceholderLabel, setVirtualNodes]);
+
+  const handleFitAll = useCallback(() => {
+    const cards: Array<{ x: number; y: number; width: number; height: number }> = [];
+    for (const entry of audioRowEntries) {
+      const pos = getPosition(entry.instanceId, entry.defaultX, entry.defaultY);
+      const outs = getAudioOutputJacks(entry.row).length;
+      const ins = getAudioInputJacks(entry.row).length;
+      cards.push({ x: pos.x, y: pos.y, width: CARD_WIDTH, height: audioCardHeight(ins, outs) });
+    }
+    for (const entry of placeholderEntries) {
+      const pos = getPosition(entry.placeholder.instanceId, entry.defaultX, entry.defaultY);
+      const outs = entry.placeholder.jacks.filter(j => j.direction === 'output').length;
+      const ins  = entry.placeholder.jacks.filter(j => j.direction === 'input').length;
+      cards.push({ x: pos.x, y: pos.y, width: CARD_WIDTH, height: audioCardHeight(ins, outs) });
+    }
+    for (const node of virtualNodes) {
+      const def = getVirtualNodeDefault(node);
+      const pos = getPosition(node.instanceId, def.x, def.y);
+      cards.push({ x: pos.x, y: pos.y, width: VIRTUAL_NODE_WIDTH, height: VIRTUAL_NODE_HEIGHT });
+    }
+    if (cards.length === 0) return;
+    viewport.fitAll(calculateBoundingBox(cards), stageDims.width, stageDims.height);
+  }, [audioRowEntries, placeholderEntries, virtualNodes, getPosition, getVirtualNodeDefault, viewport, stageDims]);
+
+  const pendingSourcePos = pendingSource ? portPositions.get(pendingSource.compositeKey) : null;
+
+  if (rows.length === 0) {
+    return <div className="workbench__canvas-placeholder">Your workbench is empty. Add products from the catalog views.</div>;
+  }
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <CanvasBase
+        scale={viewport.scale}
+        offsetX={viewport.offsetX}
+        offsetY={viewport.offsetY}
+        onWheel={viewport.handleWheel}
+        onTouchMove={viewport.handleTouchMove}
+        onTouchEnd={viewport.handleTouchEnd}
+        onStageDragEnd={viewport.handleStageDragEnd}
+        onStageClick={handleStageClick}
+        onStageMouseMove={handleStageMouseMove}
+        onDimensionsChange={handleDimensionsChange}
+      >
+        {/* Connection lines */}
+        {connections.map((conn) => {
+          const srcPos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+          const tgtPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+          if (!srcPos || !tgtPos) return null;
+          const validation = connectionValidations.get(conn.id) ?? { status: 'valid' as const, warnings: [] };
+          const isAcked = (conn.acknowledgedWarnings?.length ?? 0) > 0 &&
+            validation.warnings.every(w => conn.acknowledgedWarnings?.includes(w.key));
+          return (
+            <ConnectionLine
+              key={conn.id}
+              sourceX={srcPos.x} sourceY={srcPos.y}
+              targetX={tgtPos.x} targetY={tgtPos.y}
+              status={validation.status}
+              acknowledged={isAcked}
+              selected={selectedConnectionId === conn.id}
+              onClick={() => handleConnectionClick(conn.id)}
+            />
+          );
+        })}
+
+        {/* Preview line */}
+        {pendingSource && pendingSourcePos && mousePos && (
+          <ConnectionLine
+            sourceX={pendingSourcePos.x} sourceY={pendingSourcePos.y}
+            targetX={mousePos.x} targetY={mousePos.y}
+            status="valid"
+          />
+        )}
+
+        {/* Real product cards */}
+        {audioRowEntries.map((entry) => {
+          const pos = getPosition(entry.instanceId, entry.defaultX, entry.defaultY);
+          const outputs = getAudioOutputJacks(entry.row);
+          const inputs  = getAudioInputJacks(entry.row);
+          const cardH = audioCardHeight(inputs.length, outputs.length);
+          return (
+            <ProductCard
+              key={entry.instanceId}
+              productType={entry.row.product_type}
+              manufacturer={entry.row.manufacturer}
+              model={entry.row.model}
+              x={pos.x} y={pos.y}
+              cardHeight={cardH}
+              onDragEnd={(x, y) => handleDragEnd(entry.instanceId, x, y)}
+            >
+              {outputs.map((jack, i) => {
+                const key = portKey(entry.instanceId, jack.id);
+                const mode = getSignalMode(jack, entry.row);
+                return (
+                  <PortDot
+                    key={key}
+                    x={2} y={AUDIO_PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.id}
+                    label={jack.jack_name ?? (mode === 'stereo' ? 'Out (L/R)' : 'Out')}
+                    direction="output"
+                    color={pendingSource?.compositeKey === key ? '#fff' : '#6aaa6a'}
+                    onClick={() => handlePortClick(entry.instanceId, jack.id, 'output')}
+                  />
+                );
+              })}
+              {inputs.map((jack, i) => {
+                const key = portKey(entry.instanceId, jack.id);
+                const mode = getSignalMode(jack, entry.row);
+                return (
+                  <PortDot
+                    key={key}
+                    x={CARD_WIDTH - 2} y={AUDIO_PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.id}
+                    label={jack.jack_name ?? (mode === 'stereo' ? 'In (L/R)' : 'In')}
+                    direction="input"
+                    color={pendingSource?.compositeKey === key ? '#fff' : '#6a6aaa'}
+                    onClick={() => handlePortClick(entry.instanceId, jack.id, 'input')}
+                  />
+                );
+              })}
+            </ProductCard>
+          );
+        })}
+
+        {/* Placeholder cards */}
+        {placeholderEntries.map(({ placeholder, defaultX, defaultY }) => {
+          const pos = getPosition(placeholder.instanceId, defaultX, defaultY);
+          const outputs = placeholder.jacks.filter(j => j.direction === 'output');
+          const inputs  = placeholder.jacks.filter(j => j.direction === 'input');
+          const cardH = audioCardHeight(inputs.length, outputs.length);
+          const isSelected = selectedInstanceId === placeholder.instanceId;
+          return (
+            <ProductCard
+              key={placeholder.instanceId}
+              productType="pedal"
+              manufacturer=""
+              model={placeholder.label}
+              x={pos.x} y={pos.y}
+              cardHeight={cardH}
+              selected={isSelected}
+              onDragEnd={(x, y) => handleDragEnd(placeholder.instanceId, x, y)}
+              onClick={() => setSelectedInstanceId(placeholder.instanceId)}
+            >
+              {outputs.map((jack, i) => {
+                const key = portKey(placeholder.instanceId, jack.virtualJackId);
+                return (
+                  <PortDot
+                    key={key}
+                    x={2} y={AUDIO_PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.virtualJackId as unknown as number}
+                    label={jack.label}
+                    direction="output"
+                    color={pendingSource?.compositeKey === key ? '#fff' : '#6aaa6a'}
+                    onClick={() => handlePortClick(placeholder.instanceId, jack.virtualJackId, 'output')}
+                  />
+                );
+              })}
+              {inputs.map((jack, i) => {
+                const key = portKey(placeholder.instanceId, jack.virtualJackId);
+                return (
+                  <PortDot
+                    key={key}
+                    x={CARD_WIDTH - 2} y={AUDIO_PORT_START_Y + i * PORT_SPACING}
+                    jackId={jack.virtualJackId as unknown as number}
+                    label={jack.label}
+                    direction="input"
+                    color={pendingSource?.compositeKey === key ? '#fff' : '#6a6aaa'}
+                    onClick={() => handlePortClick(placeholder.instanceId, jack.virtualJackId, 'input')}
+                  />
+                );
+              })}
+            </ProductCard>
+          );
+        })}
+
+        {/* Virtual node cards */}
+        {virtualNodes.map((node) => {
+          const def = getVirtualNodeDefault(node);
+          const pos = getPosition(node.instanceId, def.x, def.y);
+          const isSource = node.nodeType === 'guitar_input';
+          const portX = isSource ? 2 : VIRTUAL_NODE_WIDTH - 2;
+          const portDir: 'output' | 'input' = isSource ? 'output' : 'input';
+          const pKey = portKey(node.instanceId, node.virtualJackId);
+          const isSelected = selectedInstanceId === node.instanceId;
+          const isDefault = node.instanceId === 'virtual:guitar-1' || node.instanceId === 'virtual:amp-1';
+
+          return (
+            <Group
+              key={node.instanceId}
+              x={pos.x} y={pos.y}
+              draggable
+              onClick={() => !isDefault && setSelectedInstanceId(node.instanceId)}
+              onTap={() => !isDefault && setSelectedInstanceId(node.instanceId)}
+              onDragEnd={(e: Konva.KonvaEventObject<DragEvent>) => handleDragEnd(node.instanceId, e.target.x(), e.target.y())}
+            >
+              <Rect
+                width={VIRTUAL_NODE_WIDTH} height={VIRTUAL_NODE_HEIGHT}
+                fill="#1a2a2a"
+                stroke={isSelected ? '#6adada' : '#3a7070'}
+                strokeWidth={isSelected ? 2 : 1}
+                cornerRadius={4}
+              />
+              <Text
+                x={8} y={10}
+                width={VIRTUAL_NODE_WIDTH - 16}
+                text={node.label}
+                fontSize={12}
+                fontFamily="'SF Mono', 'Fira Code', monospace"
+                fill="#6adada"
+                align="center"
+                onDblClick={() => { setEditingId(node.instanceId); setEditingLabel(node.label); }}
+                onDblTap={() => { setEditingId(node.instanceId); setEditingLabel(node.label); }}
+              />
+              <Text
+                x={8} y={28}
+                width={VIRTUAL_NODE_WIDTH - 16}
+                text={node.connectorType}
+                fontSize={9} fontFamily="monospace" fill="#555"
+                align="center" listening={false}
+              />
+              <Circle
+                x={portX} y={VIRTUAL_NODE_HEIGHT / 2}
+                radius={6}
+                fill={pendingSource?.compositeKey === pKey ? '#fff' : '#6adada'}
+                stroke="#6adada" strokeWidth={1}
+                onClick={() => handlePortClick(node.instanceId, node.virtualJackId, portDir)}
+                onTap={() => handlePortClick(node.instanceId, node.virtualJackId, portDir)}
+              />
+            </Group>
+          );
+        })}
+      </CanvasBase>
+
+      {/* Inline label editor (virtual nodes + placeholders) */}
+      {editingId && (() => {
+        const node = virtualNodes.find(n => n.instanceId === editingId);
+        const placeholder = placeholders.find(p => p.instanceId === editingId);
+        const currentLabel = node?.label ?? placeholder?.label ?? '';
+        let worldX = 0, worldY = 0;
+        if (node) {
+          const def = getVirtualNodeDefault(node);
+          const pos = getPosition(editingId, def.x, def.y);
+          worldX = pos.x + 8; worldY = pos.y + 8;
+        } else if (placeholder) {
+          const entry = placeholderEntries.find(e => e.placeholder.instanceId === editingId);
+          if (entry) {
+            const pos = getPosition(editingId, entry.defaultX, entry.defaultY);
+            worldX = pos.x + 8; worldY = pos.y + 24;
+          }
+        }
+        const screen = viewport.worldToScreen(worldX, worldY);
+        return (
+          <input
+            ref={editInputRef}
+            style={{
+              position: 'absolute', left: screen.x, top: screen.y,
+              width: (VIRTUAL_NODE_WIDTH - 16) * viewport.scale,
+              fontSize: 12 * viewport.scale,
+              background: '#1a2a2a', color: '#6adada',
+              border: '1px solid #3a7070', borderRadius: 2, padding: '2px 4px',
+            }}
+            value={editingLabel !== '' ? editingLabel : currentLabel}
+            onChange={e => setEditingLabel(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') commitLabel(editingId, editingLabel);
+              if (e.key === 'Escape') setEditingId(null);
+            }}
+            onBlur={() => commitLabel(editingId, editingLabel)}
+          />
+        );
+      })()}
+
+      {/* Stereo pair prompt */}
+      {stereoPrompt && (
+        <div className="workbench__audio-prompt" style={{ position: 'absolute', left: stereoPrompt.screenX, top: stereoPrompt.screenY }}>
+          <span className="workbench__audio-prompt-msg">Connect as stereo pair?</span>
+          <button className="workbench__power-action-btn" onClick={() => handleStereoConfirm(true)}>Yes</button>
+          <button className="workbench__power-action-btn" onClick={() => handleStereoConfirm(false)}>Just this jack</button>
+          <button className="workbench__power-action-btn" onClick={() => setStereoPrompt(null)}>Cancel</button>
+        </div>
+      )}
+
+      {/* Missing audio jacks warning */}
+      {missingRows.length > 0 && (
+        <div className="workbench__audio-missing">
+          <span className="workbench__audio-missing-title">
+            {missingRows.length} item{missingRows.length !== 1 ? 's' : ''} not shown — no audio jack data:
+          </span>
+          <ul className="workbench__audio-missing-list">
+            {missingRows.map(r => (
+              <li key={r.instanceId}>{r.manufacturer} {r.model}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Toolbar */}
+      <div className="workbench__power-actions">
+        {/* Add placeholder dropdown */}
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <button
+            className="workbench__power-action-btn"
+            onClick={() => { setShowPlaceholderMenu(v => !v); setShowNodeMenu(false); }}
+          >
+            + Add placeholder ▾
+          </button>
+          {showPlaceholderMenu && (
+            <div className="workbench__audio-menu">
+              {PLACEHOLDER_PRESETS.map(preset => (
+                <button
+                  key={preset.label}
+                  className="workbench__audio-menu-item"
+                  onClick={() => {
+                    const instanceId = `placeholder:${generateId()}`;
+                    addAudioPlaceholder({ instanceId, label: preset.label, jacks: preset.build(instanceId) });
+                    setShowPlaceholderMenu(false);
+                  }}
+                >
+                  <span>{preset.label}</span>
+                  <span className="workbench__audio-menu-desc">{preset.description}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Add virtual node dropdown */}
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <button
+            className="workbench__power-action-btn"
+            onClick={() => { setShowNodeMenu(v => !v); setShowPlaceholderMenu(false); }}
+          >
+            + Add node ▾
+          </button>
+          {showNodeMenu && (
+            <div className="workbench__audio-menu">
+              {ADDITIONAL_NODE_PRESETS.map(preset => {
+                const existingCount = virtualNodes.filter(n => n.nodeType === preset.nodeType).length;
+                return (
+                  <button
+                    key={preset.label}
+                    className="workbench__audio-menu-item"
+                    onClick={() => {
+                      const instanceId = `virtual:${preset.nodeType}-${existingCount + 1}`;
+                      addVirtualNode({
+                        instanceId,
+                        nodeType: preset.nodeType,
+                        label: preset.label,
+                        virtualJackId: preset.virtualJackId(existingCount + 1),
+                        connectorType: preset.connectorType,
+                      });
+                      setShowNodeMenu(false);
+                    }}
+                  >
+                    {preset.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {connections.length > 0 && (
+          <button
+            className="workbench__power-action-btn workbench__power-action-btn--danger"
+            onClick={() => {
+              if (window.confirm(`Clear all ${connections.length} connection${connections.length === 1 ? '' : 's'}?`)) {
+                setAudioConnections([]);
+                setSelectedConnectionId(null);
+                setWarningPopover(null);
+              }
+            }}
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      <ZoomControls
+        scale={viewport.scale}
+        onZoomIn={() => viewport.zoomIn(stageDims.width, stageDims.height)}
+        onZoomOut={() => viewport.zoomOut(stageDims.width, stageDims.height)}
+        onFitAll={handleFitAll}
+      />
+
+      {/* Floating delete button for selected connection */}
+      {selectedConnectionId && (() => {
+        const conn = connections.find(c => c.id === selectedConnectionId);
+        if (!conn) return null;
+        const srcPos = portPositions.get(portKey(conn.sourceInstanceId, conn.sourceJackId));
+        const tgtPos = portPositions.get(portKey(conn.targetInstanceId, conn.targetJackId));
+        if (!srcPos || !tgtPos) return null;
+        const mid = viewport.worldToScreen((srcPos.x + tgtPos.x) / 2, (srcPos.y + tgtPos.y) / 2);
+        return (
+          <button
+            className="workbench__power-delete-btn"
+            style={{ position: 'absolute', left: mid.x, top: mid.y }}
+            onClick={() => { removeAudioConnection(selectedConnectionId); setSelectedConnectionId(null); setWarningPopover(null); }}
+          >×</button>
+        );
+      })()}
+
+      {/* Warning popover */}
+      {warningPopover && (() => {
+        const screenPos = viewport.worldToScreen(warningPopover.x, warningPopover.y);
+        return (
+          <div className="workbench__power-popover" style={{ position: 'absolute', left: screenPos.x, top: screenPos.y }}>
+            <div className="workbench__power-popover-warnings">
+              {warningPopover.warnings.map(w => {
+                const conn = connections.find(c => c.id === warningPopover.connId);
+                const acked = conn?.acknowledgedWarnings?.includes(w.key);
+                return (
+                  <div key={w.key} className="workbench__power-popover-warning">
+                    <span>{w.message}</span>
+                    {acked
+                      ? <span className="workbench__power-popover-acked">Acknowledged</span>
+                      : <button className="workbench__power-popover-btn" onClick={() => acknowledgeAudioWarning(warningPopover.connId, w.key)}>
+                          {w.adapterImplication ? 'I have this adapter' : 'Got it'}
+                        </button>
+                    }
+                  </div>
+                );
+              })}
+            </div>
+            <button className="workbench__power-popover-btn workbench__power-popover-btn--close" onClick={() => setWarningPopover(null)}>Close</button>
+          </div>
+        );
+      })()}
+    </div>
+  );
+};
+
+export default AudioView;

--- a/apps/web/src/components/Workbench/AudioView.tsx
+++ b/apps/web/src/components/Workbench/AudioView.tsx
@@ -147,7 +147,7 @@ const ADDITIONAL_NODE_PRESETS: Array<{
   virtualJackId: (n: number) => string;
   connectorType: string;
 }> = [
-  { label: 'Second Amp',    nodeType: 'secondary_amp_input', virtualJackId: (n) => `virtual-jack:amp2-in-${n}`,    connectorType: '1/4" TS' },
+  { label: 'Amp',           nodeType: 'secondary_amp_input', virtualJackId: (n) => `virtual-jack:amp2-in-${n}`,    connectorType: '1/4" TS' },
   { label: 'FRFR / Speaker', nodeType: 'frfr_input',          virtualJackId: (n) => `virtual-jack:frfr-in-${n}`,   connectorType: '1/4" TS' },
   { label: 'Direct Out (FOH)', nodeType: 'direct_output',     virtualJackId: (n) => `virtual-jack:direct-out-${n}`, connectorType: 'XLR' },
   { label: 'Tuner Out',     nodeType: 'tuner_output',         virtualJackId: (n) => `virtual-jack:tuner-out-${n}`,  connectorType: '1/4" TS' },
@@ -314,10 +314,9 @@ const AudioView = ({ rows }: AudioViewProps) => {
       const pos = getPosition(entry.placeholder.instanceId, entry.defaultX, entry.defaultY);
       const outputs = entry.placeholder.jacks.filter(j => j.direction === 'output');
       const inputs  = entry.placeholder.jacks.filter(j => j.direction === 'input');
-      const cardH = audioCardHeight(inputs.length, outputs.length);
       outputs.forEach((jack, i) => map.set(portKey(entry.placeholder.instanceId, jack.virtualJackId), {
         x: pos.x + 2,
-        y: pos.y + Math.max(0, cardH - CARD_HEIGHT) + AUDIO_PORT_START_Y - Math.max(0, cardH - CARD_HEIGHT) + AUDIO_PORT_START_Y - (AUDIO_PORT_START_Y - (CARD_HEIGHT - 4)) + i * PORT_SPACING,
+        y: pos.y + AUDIO_PORT_START_Y + i * PORT_SPACING,
       }));
       inputs.forEach((jack, i) => map.set(portKey(entry.placeholder.instanceId, jack.virtualJackId), {
         x: pos.x + CARD_WIDTH - 2,
@@ -413,13 +412,25 @@ const AudioView = ({ rows }: AudioViewProps) => {
       const sourceInstanceId = direction === 'input' ? pendingSource.instanceId : instanceId;
       const targetInstanceId = direction === 'input' ? instanceId : pendingSource.instanceId;
 
-      // Check stereo: both jacks must be real jacks with a stereo partner
+      // Check stereo: real jacks with a stereo partner, or placeholder jacks with a group_id partner
       const srcJack = typeof sourceJackId === 'number' ? jackMap.get(sourceJackId) : null;
       const tgtJack = typeof targetJackId === 'number' ? jackMap.get(targetJackId) : null;
       const srcRow = rowMap.get(sourceInstanceId);
       const tgtRow = rowMap.get(targetInstanceId);
-      const srcHasStereo = srcJack && srcRow && srcJack.group_id !== null && !!getStereoPartner(srcJack, srcRow.jacks);
-      const tgtHasStereo = tgtJack && tgtRow && tgtJack.group_id !== null && !!getStereoPartner(tgtJack, tgtRow.jacks);
+      const placeholderHasStereoPartner = (id: number | string, instanceId: string): boolean => {
+        if (typeof id !== 'string') return false;
+        const p = placeholders.find(pl => pl.instanceId === instanceId);
+        if (!p) return false;
+        const spec = p.jacks.find(j => j.virtualJackId === id);
+        if (!spec || !spec.group_id) return false;
+        return p.jacks.some(j => j.virtualJackId !== id && j.group_id === spec.group_id);
+      };
+      const srcHasStereo =
+        (srcJack && srcRow && srcJack.group_id !== null && !!getStereoPartner(srcJack, srcRow.jacks)) ||
+        placeholderHasStereoPartner(sourceJackId, sourceInstanceId);
+      const tgtHasStereo =
+        (tgtJack && tgtRow && tgtJack.group_id !== null && !!getStereoPartner(tgtJack, tgtRow.jacks)) ||
+        placeholderHasStereoPartner(targetJackId, targetInstanceId);
 
       if (srcHasStereo && tgtHasStereo) {
         const srcPos = portPositions.get(portKey(sourceInstanceId, sourceJackId));
@@ -435,7 +446,7 @@ const AudioView = ({ rows }: AudioViewProps) => {
         setMousePos(null);
       }
     }
-  }, [pendingSource, jackMap, rowMap, portPositions, viewport]);
+  }, [pendingSource, jackMap, rowMap, portPositions, viewport, placeholders]);
 
   const createConnection = useCallback((
     sourceJackId: number | string, sourceInstanceId: string,
@@ -463,15 +474,28 @@ const AudioView = ({ rows }: AudioViewProps) => {
       const srcPartner = srcJack && srcRow ? getStereoPartner(srcJack, srcRow.jacks) : undefined;
       const tgtPartner = tgtJack && tgtRow ? getStereoPartner(tgtJack, tgtRow.jacks) : undefined;
 
+      const findPlaceholderPartner = (id: number | string, instanceId: string): VirtualJackSpec | undefined => {
+        if (typeof id !== 'string') return undefined;
+        const p = placeholders.find(pl => pl.instanceId === instanceId);
+        if (!p) return undefined;
+        const spec = p.jacks.find(j => j.virtualJackId === id);
+        if (!spec || !spec.group_id) return undefined;
+        return p.jacks.find(j => j.virtualJackId !== id && j.group_id === spec.group_id);
+      };
+      const srcPlaceholderPartner = findPlaceholderPartner(sourceJackId, sourceInstanceId);
+      const tgtPlaceholderPartner = findPlaceholderPartner(targetJackId, targetInstanceId);
+
       createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'stereo', null);
       if (srcPartner && tgtPartner) {
         createConnection(srcPartner.id, sourceInstanceId, tgtPartner.id, targetInstanceId, 'stereo', null);
+      } else if (srcPlaceholderPartner && tgtPlaceholderPartner) {
+        createConnection(srcPlaceholderPartner.virtualJackId, sourceInstanceId, tgtPlaceholderPartner.virtualJackId, targetInstanceId, 'stereo', null);
       }
     } else {
       createConnection(sourceJackId, sourceInstanceId, targetJackId, targetInstanceId, 'mono', null);
     }
     setStereoPrompt(null);
-  }, [stereoPrompt, jackMap, rowMap, createConnection]);
+  }, [stereoPrompt, jackMap, rowMap, placeholders, createConnection]);
 
   const handleStageMouseMove = useCallback((e: Konva.KonvaEventObject<MouseEvent>) => {
     if (!pendingSource) return;
@@ -711,6 +735,7 @@ const AudioView = ({ rows }: AudioViewProps) => {
               selected={isSelected}
               onDragEnd={(x, y) => handleDragEnd(placeholder.instanceId, x, y)}
               onClick={() => setSelectedInstanceId(placeholder.instanceId)}
+              onDblClick={() => { setEditingId(placeholder.instanceId); setEditingLabel(placeholder.label); }}
             >
               {outputs.map((jack, i) => {
                 const key = portKey(placeholder.instanceId, jack.virtualJackId);

--- a/apps/web/src/components/Workbench/ConnectionLine.tsx
+++ b/apps/web/src/components/Workbench/ConnectionLine.tsx
@@ -1,4 +1,5 @@
 import { Line } from 'react-konva';
+import { RouteWaypoint } from '../../types/connections';
 
 const STATUS_COLORS = {
   valid: '#6aaa6a',
@@ -17,6 +18,7 @@ interface ConnectionLineProps {
   acknowledged?: boolean;
   onClick?: () => void;
   selected?: boolean;
+  waypoints?: RouteWaypoint[];
 }
 
 /**
@@ -32,26 +34,37 @@ const ConnectionLine = ({
   acknowledged = false,
   onClick,
   selected = false,
+  waypoints,
 }: ConnectionLineProps) => {
   const color = acknowledged ? ACKNOWLEDGED_COLOR : STATUS_COLORS[status];
   const strokeWidth = selected ? 3 : 2;
 
+  const commonProps = {
+    stroke: color,
+    strokeWidth,
+    dash: acknowledged ? [6, 4] : undefined,
+    hitStrokeWidth: 12,
+    onClick,
+    onTap: onClick,
+    shadowColor: selected ? color : undefined,
+    shadowBlur: selected ? 8 : 0,
+    shadowOpacity: selected ? 0.5 : 0,
+  };
+
+  if (waypoints && waypoints.length > 0) {
+    const pts: number[] = [sourceX, sourceY];
+    for (const wp of waypoints) pts.push(wp.x, wp.y);
+    pts.push(targetX, targetY);
+    return <Line points={pts} {...commonProps} />;
+  }
+
   // Bezier control point offset — curve bows out horizontally
   const dx = Math.abs(targetX - sourceX) * 0.4;
-
   return (
     <Line
       points={[sourceX, sourceY, sourceX + dx, sourceY, targetX - dx, targetY, targetX, targetY]}
-      stroke={color}
-      strokeWidth={strokeWidth}
       bezier
-      dash={acknowledged ? [6, 4] : undefined}
-      hitStrokeWidth={12}
-      onClick={onClick}
-      onTap={onClick}
-      shadowColor={selected ? color : undefined}
-      shadowBlur={selected ? 8 : 0}
-      shadowOpacity={selected ? 0.5 : 0}
+      {...commonProps}
     />
   );
 };

--- a/apps/web/src/components/Workbench/ProductCard.tsx
+++ b/apps/web/src/components/Workbench/ProductCard.tsx
@@ -23,6 +23,7 @@ interface ProductCardProps {
   y: number;
   onDragEnd: (x: number, y: number) => void;
   onClick?: () => void;
+  onDblClick?: () => void;
   selected?: boolean;
   children?: ReactNode;
   /** Override card width (e.g., proportional sizing in Layout view) */
@@ -45,6 +46,7 @@ const ProductCard = ({
   y,
   onDragEnd,
   onClick,
+  onDblClick,
   selected = false,
   children,
   cardWidth,
@@ -65,6 +67,8 @@ const ProductCard = ({
       }}
       onClick={onClick}
       onTap={onClick}
+      onDblClick={onDblClick}
+      onDblTap={onDblClick}
     >
       {/* Inner group for center-pivot rotation. Translates to center, rotates, then offsets back. */}
       <Group

--- a/apps/web/src/components/Workbench/ViewNav.tsx
+++ b/apps/web/src/components/Workbench/ViewNav.tsx
@@ -8,7 +8,7 @@ interface ViewTab {
 
 const VIEW_TABS: ViewTab[] = [
   { key: 'layout', label: 'Layout', enabled: true },
-  { key: 'audio', label: 'Audio', enabled: false },
+  { key: 'audio', label: 'Audio', enabled: true },
   { key: 'power', label: 'Power', enabled: true },
   { key: 'midi', label: 'MIDI', enabled: false },
   { key: 'control', label: 'Control', enabled: false },

--- a/apps/web/src/components/Workbench/index.scss
+++ b/apps/web/src/components/Workbench/index.scss
@@ -355,6 +355,104 @@
     }
   }
 
+  // Audio view — missing items notice
+  &__audio-missing {
+    position: absolute;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(20, 16, 10, 0.92);
+    border: 1px solid #4a3a20;
+    border-radius: 5px;
+    padding: 7px 14px;
+    z-index: 10;
+    max-width: 420px;
+    font-size: 11px;
+    font-family: monospace;
+    pointer-events: none;
+    white-space: nowrap;
+  }
+
+  &__audio-missing-title {
+    color: #d4a55a;
+  }
+
+  &__audio-missing-list {
+    margin: 4px 0 0;
+    padding-left: 16px;
+    list-style: disc;
+    color: #888;
+    font-size: 10px;
+  }
+
+  // Audio view — add placeholder / add node dropdown menus
+  &__audio-menu {
+    position: absolute;
+    bottom: calc(100% + 4px);
+    left: 0;
+    min-width: 200px;
+    background: #1e1e1e;
+    border: 1px solid #333;
+    border-radius: 5px;
+    z-index: 20;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  &__audio-menu-item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 8px 12px;
+    border: none;
+    border-bottom: 1px solid #2a2a2a;
+    background: transparent;
+    color: #ccc;
+    font-family: monospace;
+    font-size: 12px;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.1s;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    &:hover {
+      background: #2a2a2a;
+      color: #f0f0f0;
+    }
+  }
+
+  &__audio-menu-desc {
+    font-size: 10px;
+    color: #666;
+    margin-top: 2px;
+  }
+
+  // Audio view — stereo pair prompt
+  &__audio-prompt {
+    background: #1e1e1e;
+    border: 1px solid #3a7070;
+    border-radius: 6px;
+    padding: 10px 14px;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+    font-family: monospace;
+    font-size: 12px;
+    transform: translateX(-50%);
+  }
+
+  &__audio-prompt-msg {
+    color: #6adada;
+    margin-right: 4px;
+  }
+
   &__table-wrapper {
     overflow-x: auto;
   }

--- a/apps/web/src/components/Workbench/index.tsx
+++ b/apps/web/src/components/Workbench/index.tsx
@@ -4,6 +4,7 @@ import WorkbenchTableView, { useWorkbenchProducts, WorkbenchRow } from './Workbe
 import DetailPanel from './DetailPanel';
 import InsightsSidebar from './InsightsSidebar';
 import ViewNav, { ViewMode } from './ViewNav';
+import AudioView from './AudioView';
 import LayoutView from './LayoutView';
 import PowerView from './PowerView';
 import './index.scss';
@@ -104,6 +105,13 @@ const Workbench = () => {
         return (
           <div className="workbench__content workbench__content--canvas">
             <LayoutView rows={rows} />
+          </div>
+        );
+
+      case 'audio':
+        return (
+          <div className="workbench__content workbench__content--canvas">
+            <AudioView rows={rows} />
           </div>
         );
 

--- a/apps/web/src/context/WorkbenchContext.tsx
+++ b/apps/web/src/context/WorkbenchContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from 'react';
+import { AudioConnection, VirtualNode, AudioPlaceholder, RouteWaypoint } from '../types/connections';
 
 // --- Types ---
 
@@ -55,6 +56,9 @@ export interface Workbench {
   // Canvas view data:
   viewPositions?: ViewPositions;
   powerConnections?: PowerConnection[];
+  audioConnections?: AudioConnection[];
+  virtualNodes?: VirtualNode[];
+  audioPlaceholders?: AudioPlaceholder[];
   viewportStates?: ViewportStates;
 }
 
@@ -93,6 +97,23 @@ interface WorkbenchContextType {
   removePowerConnection: (connId: string) => void;
   setPowerConnections: (conns: PowerConnection[]) => void;
   acknowledgeWarning: (connId: string, warningKey: string) => void;
+
+  // Audio connections
+  addAudioConnection: (conn: Omit<AudioConnection, 'id'>) => void;
+  removeAudioConnection: (connId: string) => void;
+  setAudioConnections: (conns: AudioConnection[]) => void;
+  acknowledgeAudioWarning: (connId: string, warningKey: string) => void;
+  updateAudioConnectionWaypoints: (connId: string, waypoints: RouteWaypoint[]) => void;
+
+  // Virtual nodes
+  addVirtualNode: (node: VirtualNode) => void;
+  removeVirtualNode: (instanceId: string) => void;
+  setVirtualNodes: (nodes: VirtualNode[]) => void;
+
+  // Audio placeholders
+  addAudioPlaceholder: (placeholder: AudioPlaceholder) => void;
+  removeAudioPlaceholder: (instanceId: string) => void;
+  updateAudioPlaceholderLabel: (instanceId: string, label: string) => void;
 
   // Aggregate counts
   totalItemCount: number;
@@ -364,6 +385,108 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     })));
   }, [updateStore]);
 
+  // --- Audio connections ---
+
+  const addAudioConnection = useCallback((conn: Omit<AudioConnection, 'id'>) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: [...(wb.audioConnections || []), { ...conn, id: generateId() }],
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const removeAudioConnection = useCallback((connId: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: (wb.audioConnections || []).filter(c => c.id !== connId),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const setAudioConnections = useCallback((conns: AudioConnection[]) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: conns,
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const acknowledgeAudioWarning = useCallback((connId: string, warningKey: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: (wb.audioConnections || []).map(c =>
+        c.id === connId
+          ? { ...c, acknowledgedWarnings: [...(c.acknowledgedWarnings || []), warningKey] }
+          : c,
+      ),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const updateAudioConnectionWaypoints = useCallback((connId: string, waypoints: RouteWaypoint[]) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioConnections: (wb.audioConnections || []).map(c =>
+        c.id === connId ? { ...c, waypoints } : c,
+      ),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  // --- Virtual nodes ---
+
+  const addVirtualNode = useCallback((node: VirtualNode) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      virtualNodes: [...(wb.virtualNodes || []), node],
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const removeVirtualNode = useCallback((instanceId: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      virtualNodes: (wb.virtualNodes || []).filter(n => n.instanceId !== instanceId),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const setVirtualNodes = useCallback((nodes: VirtualNode[]) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      virtualNodes: nodes,
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  // --- Audio placeholders ---
+
+  const addAudioPlaceholder = useCallback((placeholder: AudioPlaceholder) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioPlaceholders: [...(wb.audioPlaceholders || []), placeholder],
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const removeAudioPlaceholder = useCallback((instanceId: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioPlaceholders: (wb.audioPlaceholders || []).filter(p => p.instanceId !== instanceId),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
+  const updateAudioPlaceholderLabel = useCallback((instanceId: string, label: string) => {
+    updateStore(prev => updateActiveWorkbench(prev, wb => ({
+      ...wb,
+      audioPlaceholders: (wb.audioPlaceholders || []).map(p =>
+        p.instanceId === instanceId ? { ...p, label } : p,
+      ),
+      updatedAt: new Date().toISOString(),
+    })));
+  }, [updateStore]);
+
   const totalItemCount = useMemo(
     () => activeWorkbench.items.length,
     [activeWorkbench],
@@ -391,9 +514,20 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
       removePowerConnection,
       setPowerConnections,
       acknowledgeWarning,
+      addAudioConnection,
+      removeAudioConnection,
+      setAudioConnections,
+      acknowledgeAudioWarning,
+      updateAudioConnectionWaypoints,
+      addVirtualNode,
+      removeVirtualNode,
+      setVirtualNodes,
+      addAudioPlaceholder,
+      removeAudioPlaceholder,
+      updateAudioPlaceholderLabel,
       totalItemCount,
     }),
-    [store.workbenches, activeWorkbench, createWorkbench, renameWorkbench, deleteWorkbench, setActiveWorkbench, addItem, removeItem, removeAllInstances, countInWorkbench, clear, updateViewPosition, updateCardTransform, getViewPositions, getViewportState, updateViewportState, addPowerConnection, removePowerConnection, setPowerConnections, acknowledgeWarning, totalItemCount],
+    [store.workbenches, activeWorkbench, createWorkbench, renameWorkbench, deleteWorkbench, setActiveWorkbench, addItem, removeItem, removeAllInstances, countInWorkbench, clear, updateViewPosition, updateCardTransform, getViewPositions, getViewportState, updateViewportState, addPowerConnection, removePowerConnection, setPowerConnections, acknowledgeWarning, addAudioConnection, removeAudioConnection, setAudioConnections, acknowledgeAudioWarning, updateAudioConnectionWaypoints, addVirtualNode, removeVirtualNode, setVirtualNodes, addAudioPlaceholder, removeAudioPlaceholder, updateAudioPlaceholderLabel, totalItemCount],
   );
 
   return (

--- a/apps/web/src/types/connections.ts
+++ b/apps/web/src/types/connections.ts
@@ -1,0 +1,72 @@
+export interface RouteWaypoint { x: number; y: number; }
+
+export interface AudioConnection {
+  id: string;
+  sourceJackId: number | string;   // number for real jacks, string for virtual/placeholder
+  targetJackId: number | string;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  orderIndex: number;
+  parallelPathId: string | null;
+  fxLoopGroupId: string | null;
+  signalMode: 'mono' | 'stereo';
+  stereoPairConnectionId: string | null;
+  waypoints: RouteWaypoint[];      // always [] in AudioView; reserved for Layout cable routing
+}
+
+export type VirtualNodeType =
+  | 'guitar_input'
+  | 'amp_input' | 'amp_fx_send' | 'amp_fx_return'
+  | 'secondary_amp_input'
+  | 'frfr_input'
+  | 'direct_output'          // FOH / audio interface send
+  | 'tuner_output';
+
+export interface VirtualNode {
+  instanceId: string;       // e.g. 'virtual:guitar-1'
+  nodeType: VirtualNodeType;
+  label: string;            // user-editable
+  virtualJackId: string;    // e.g. 'virtual-jack:guitar-out'
+  connectorType: string;    // '1/4" TS', 'XLR', etc.
+}
+
+/** A single configurable jack on a placeholder item */
+export interface VirtualJackSpec {
+  virtualJackId: string;    // e.g. 'placeholder:inst-x:out-0'
+  direction: 'input' | 'output';
+  connectorType: string;
+  label: string;
+  group_id: string | null;  // non-null links this jack to its stereo partner
+}
+
+/** A user-defined placeholder item with configurable jack layout, for planning
+ *  signal chains before all gear is entered in the database. */
+export interface AudioPlaceholder {
+  instanceId: string;       // e.g. 'placeholder:uuid'
+  label: string;            // user-editable, e.g. 'Reverb pedal'
+  jacks: VirtualJackSpec[];
+}
+
+// Stubs for Phases 3–4 (defined but unused until MIDI/Control views)
+export interface MidiConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  midiChannel: number | null;
+  routesMidiClock: boolean;
+}
+
+export interface ControlConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+  controlType: 'expression' | 'aux_switch' | 'cv' | 'other';
+  polarityNormal: boolean;
+}

--- a/apps/web/src/utils/audioUtils.ts
+++ b/apps/web/src/utils/audioUtils.ts
@@ -1,0 +1,129 @@
+import { Jack } from './transformers';
+import { AudioConnection } from '../types/connections';
+import { ConnectionValidation, ConnectionWarning } from './connectionValidation';
+
+// --- Jack filtering helpers ---
+
+export function getAudioInputJacks(row: { jacks: Jack[] }): Jack[] {
+  return row.jacks.filter(j => j.category === 'audio' && j.direction === 'input');
+}
+
+export function getAudioOutputJacks(row: { jacks: Jack[] }): Jack[] {
+  return row.jacks.filter(j => j.category === 'audio' && j.direction === 'output');
+}
+
+export function hasAudioJacks(row: { jacks: Jack[] }): boolean {
+  return row.jacks.some(j => j.category === 'audio');
+}
+
+export function getStereoPartner(jack: Jack, allJacks: Jack[]): Jack | undefined {
+  if (!jack.group_id) return undefined;
+  return allJacks.find(j => j.id !== jack.id && j.group_id === jack.group_id);
+}
+
+// --- Cycle detection ---
+
+export function wouldCreateCycle(
+  sourceInstanceId: string,
+  targetInstanceId: string,
+  existingConnections: AudioConnection[],
+): boolean {
+  // BFS: can we reach sourceInstanceId starting from targetInstanceId?
+  const visited = new Set<string>();
+  const queue: string[] = [targetInstanceId];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current === sourceInstanceId) return true;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    for (const conn of existingConnections) {
+      if (conn.sourceInstanceId === current && !visited.has(conn.targetInstanceId)) {
+        queue.push(conn.targetInstanceId);
+      }
+    }
+  }
+
+  return false;
+}
+
+// --- Connection validation ---
+
+export function validateAudioConnection(
+  sourceJack: { connector_type: string | null; group_id: string | null; impedance_ohms: number | null },
+  targetJack: { connector_type: string | null; group_id: string | null; impedance_ohms: number | null },
+  sourceSignalMode: 'mono' | 'stereo',
+  targetSignalMode: 'mono' | 'stereo',
+  existingConnections: AudioConnection[],
+  sourceInstanceId: string,
+  targetInstanceId: string,
+): ConnectionValidation {
+  const warnings: ConnectionWarning[] = [];
+
+  // Circular connection check (error)
+  if (wouldCreateCycle(sourceInstanceId, targetInstanceId, existingConnections)) {
+    warnings.push({
+      key: 'audio:circular-connection',
+      severity: 'error',
+      message: 'This connection would create a feedback loop in the signal chain.',
+    });
+  }
+
+  // Connector mismatch (warning + adapter)
+  if (
+    sourceJack.connector_type &&
+    targetJack.connector_type &&
+    sourceJack.connector_type !== targetJack.connector_type
+  ) {
+    warnings.push({
+      key: 'audio:connector-mismatch',
+      severity: 'warning',
+      message: `Connector mismatch: ${sourceJack.connector_type} → ${targetJack.connector_type}. An adapter cable is needed.`,
+      adapterImplication: {
+        fromConnectorType: sourceJack.connector_type,
+        toConnectorType: targetJack.connector_type,
+        description: `${sourceJack.connector_type} to ${targetJack.connector_type} adapter`,
+      },
+    });
+  }
+
+  // Mono → stereo
+  if (sourceSignalMode === 'mono' && targetSignalMode === 'stereo') {
+    warnings.push({
+      key: 'audio:mono-to-stereo',
+      severity: 'warning',
+      message: 'Connecting a mono output to a stereo input — the right channel will be silent.',
+    });
+  }
+
+  // Stereo → mono
+  if (sourceSignalMode === 'stereo' && targetSignalMode === 'mono') {
+    warnings.push({
+      key: 'audio:stereo-to-mono',
+      severity: 'warning',
+      message: 'Connecting a stereo output to a mono input — the signal will be summed or the left channel only will pass.',
+    });
+  }
+
+  // Impedance mismatch
+  if (
+    sourceJack.impedance_ohms !== null &&
+    targetJack.impedance_ohms !== null &&
+    targetJack.impedance_ohms / sourceJack.impedance_ohms > 100
+  ) {
+    warnings.push({
+      key: 'audio:impedance-mismatch',
+      severity: 'warning',
+      message: `Impedance mismatch: source ${sourceJack.impedance_ohms}Ω → target ${targetJack.impedance_ohms}Ω. Signal loss may occur.`,
+    });
+  }
+
+  const hasError = warnings.some(w => w.severity === 'error');
+  const hasWarning = warnings.some(w => w.severity === 'warning');
+
+  return {
+    status: hasError ? 'error' : hasWarning ? 'warning' : 'valid',
+    warnings,
+  };
+}

--- a/apps/web/src/utils/transformers.ts
+++ b/apps/web/src/utils/transformers.ts
@@ -24,6 +24,7 @@ export interface Jack {
   is_buffered: boolean | null;
   has_ground_lift: boolean | null;
   has_phase_invert: boolean | null;
+  group_id: string | null;
 }
 
 function transformJack(dto: JackApiResponse): Jack {
@@ -43,6 +44,7 @@ function transformJack(dto: JackApiResponse): Jack {
     is_buffered: dto.isBuffered,
     has_ground_lift: dto.hasGroundLift,
     has_phase_invert: dto.hasPhaseInvert,
+    group_id: dto.groupId,
   };
 }
 


### PR DESCRIPTION
## Summary

- **AudioView canvas** with right-to-left signal flow — output ports on left, input ports on right, positioned below card text to avoid overlap
- **Placeholder items** — 5 presets (mono pedal, stereo, mono-in/stereo-out, mono FX loop, stereo FX loop) for planning before all DB data is entered; configurable jack specs via `VirtualJackSpec`
- **Virtual signal endpoint nodes** — 6 types: guitar input, amp input, second amp, FRFR/speaker, direct output (FOH), tuner out; default guitar + amp nodes auto-initialize
- **Missing data warnings** — rows with no audio jacks shown in a fixed panel at the top, not hidden silently
- **Connection validation** — connector mismatch (with adapter implication), mono→stereo, stereo→mono, impedance mismatch (>100:1 ratio), cycle detection
- **Stereo pair prompt** — when both source and target jacks have a `group_id` partner, user is asked to connect as stereo pair or just this jack
- **Inline label editing** — double-click virtual node or placeholder card to edit label
- **Waypoints** — `ConnectionLine` accepts `waypoints` prop and `AudioConnection.waypoints` field retained (dormant; exposed by Layout view cable routing in a future phase, per `docs/plans/audio-cable-routing-waypoints.md`)
- **`group_id` added to `Jack` type** and `transformJack` mapping (was in API response but not mapped)
- **`audioConnections`, `virtualNodes`, `audioPlaceholders`** added to `WorkbenchContext` with full CRUD methods
- **23 new `audioUtils` tests** (jack helpers, cycle detection, connection validation); 45 total tests passing, build clean

## Addresses feedback from PR #52
- Port dots now render below card text (`AUDIO_PORT_START_Y = CARD_HEIGHT - 4`; card height extends by port count)
- Waypoint editing UI removed from AudioView; infrastructure kept dormant for future Layout view use
- Items missing audio jacks get a warning panel instead of being silently absent

## Test plan
- [x] Audio tab is clickable
- [x] Items with audio jacks appear on canvas with L/R port dots
- [x] Guitar and amp virtual nodes appear automatically
- [x] "Add placeholder ▾" dropdown adds configurable pedal cards
- [x] "Add node ▾" dropdown adds additional virtual endpoint nodes
- [x] Click output port → preview line follows mouse → click input port → connection created
- [x] Stereo jack pair triggers "Connect as stereo pair?" prompt
- [x] Connection with connector mismatch shows warning popover; acknowledge button works
- [x] ESC cancels pending connection; Delete removes selected connection
- [x] Items with no audio jacks listed in the warning panel at top
- [x] All 45 tests pass: `npm run web:test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)