### PR TITLE
Plan: Phase 3 MIDI connections view

### DIFF
--- a/docs/plans/midi-connections-phase-3.md
+++ b/docs/plans/midi-connections-phase-3.md
@@ -173,12 +173,15 @@ Since `trsMidiStandard` isn't a column on the `jacks` table yet (no per-jack TRS
 
 ### Canvas layout
 
-- **Flow direction:** top-to-bottom — MIDI signal flows from controller down/out to connected devices, then chains further down. MIDI controllers render at **bottom center**; connected devices above arranged by chain depth.
+- **Flow direction:** bottom-to-top — MIDI signal flows from controller upward to connected devices, then chains further up. MIDI controllers render at **bottom center**; connected devices above arranged by chain depth.
 - **Port positions:**
-  - MIDI output port: bottom edge of card — `y ≈ CARD_HEIGHT - 4`
-  - MIDI input port: top edge of card — `y ≈ 4`
-  - Both ports centered horizontally on the card: `x = CARD_WIDTH / 2`
-- **Port spacing:** N/A — MIDI devices typically have at most one in + one out + one thru. All ports render at the horizontal center. If multiple ports exist (e.g., a thru alongside an out), offset them horizontally by ±16px.
+  - MIDI output ports: top edge of card — `y ≈ 4` (signal exits upward toward connected devices)
+  - MIDI input ports: bottom edge of card — `y ≈ CARD_HEIGHT - 4` (signal enters from below, from the controller)
+- **Port spacing:** Multiple ports of the same direction (e.g., a MIDI hub with 4 outputs like the Disaster Area MIDI Box 4) are spaced evenly across the card's top or bottom edge with a fixed horizontal margin:
+  - Single port: centered at `x = CARD_WIDTH / 2`
+  - Multiple ports: `x = MIDI_PORT_MARGIN + i * (effectiveWidth - 2 * MIDI_PORT_MARGIN) / (portCount - 1)` where `MIDI_PORT_MARGIN = 8`
+  - If `portCount > 3`, the card width is extended proportionally so ports don't crowd: `midiCardWidth(portCount) = Math.max(CARD_WIDTH, portCount * 28 + 2 * MIDI_PORT_MARGIN)`
+  - Port width expansion is analogous to AudioView's `audioCardHeight()` height expansion for many audio ports
 
 ### Default positions (first render)
 

--- a/docs/plans/midi-connections-phase-3.md
+++ b/docs/plans/midi-connections-phase-3.md
@@ -1,0 +1,361 @@
+# Phase 3: MIDI Connections View
+
+## Context
+
+Phases 1 and 2 are complete and merged to main:
+
+- **Phase 1** — Shared `ConnectionWarning`/`ConnectionValidation` types live in `utils/connectionValidation.ts`; `powerUtils.ts` uses structured warnings.
+- **Phase 2** — `AudioView.tsx` is live. `AudioConnection`, `VirtualNode`, `AudioPlaceholder`, `VirtualJackSpec` types exist in `types/connections.ts`. `WorkbenchContext` has audio CRUD methods.
+
+`MidiConnection` and `ControlConnection` are already stub-defined in `types/connections.ts` but incomplete (missing `chainIndex`, `trsMidiStandard`, `carriesClock`). This phase expands the stubs, adds context methods, builds the validation utility, and creates the `MidiView` canvas.
+
+**Reference implementation:** `AudioView.tsx` (1029 lines). Follow its patterns for canvas setup, port dot rendering, connection creation flow, pending state, warning popover, toolbar, and empty state.
+
+**Key RJM PBC/6X note:** The first seeded MIDI controller (`product_id = 189`) has only ONE physical MIDI port — output-only by default. MIDI input requires a Y-cable accessory. The view must handle output-only devices gracefully and not assume every MIDI-capable product has both in and out jacks.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|---|---|
+| `apps/web/src/utils/midiUtils.ts` | MIDI jack helpers + `validateMidiConnection()` |
+| `apps/web/src/components/Workbench/MidiView.tsx` | MIDI connections canvas |
+| `apps/web/src/__tests__/utils/midiUtils.test.ts` | Tests for midiUtils |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `apps/web/src/types/connections.ts` | Expand `MidiConnection` stub (add `chainIndex`, `trsMidiStandard`, rename `routesMidiClock` → `carriesClock`) |
+| `apps/web/src/context/WorkbenchContext.tsx` | Add `midiConnections` to Workbench interface + CRUD methods |
+| `apps/web/src/components/Workbench/ViewNav.tsx` | `enabled: false` → `enabled: true` for MIDI tab |
+| `apps/web/src/components/Workbench/index.tsx` | Import MidiView, add `case 'midi':` |
+| `apps/web/src/components/Workbench/index.scss` | Add `.workbench__midi-*` classes (channel badge, TRS selector) |
+
+---
+
+## Step 1: Expand `MidiConnection` type in `connections.ts`
+
+Replace the stub (lines 52–61) with the full type:
+
+```typescript
+export interface MidiConnection {
+  id: string;
+  sourceJackId: number;
+  targetJackId: number;
+  sourceInstanceId: string;
+  targetInstanceId: string;
+  acknowledgedWarnings?: string[];
+
+  // MIDI-specific
+  chainIndex: number;                          // Position in daisy chain (0 = first from controller)
+  midiChannel: number | null;                  // 1–16, null = omni
+  carriesClock: boolean;                       // Whether this connection routes MIDI clock
+  trsMidiStandard: 'TRS-A' | 'TRS-B' | null;  // Only for 3.5mm TRS connectors; null = unknown
+}
+```
+
+No changes needed to `ControlConnection` stub — that's Phase 4.
+
+---
+
+## Step 2: `WorkbenchContext.tsx` — MIDI CRUD methods
+
+### Workbench interface additions
+```typescript
+midiConnections?: MidiConnection[];
+```
+
+Import `MidiConnection` (already imported as part of the connections import if shared; otherwise add it).
+
+### New context methods (exact same pattern as audio methods)
+```typescript
+addMidiConnection: (conn: Omit<MidiConnection, 'id'>) => void;
+removeMidiConnection: (connId: string) => void;
+setMidiConnections: (conns: MidiConnection[]) => void;
+acknowledgeMidiWarning: (connId: string, warningKey: string) => void;
+updateMidiConnection: (connId: string, updates: Partial<Pick<MidiConnection, 'midiChannel' | 'carriesClock' | 'trsMidiStandard'>>) => void;
+```
+
+`updateMidiConnection` is new (AudioView didn't need it) — lets the channel badge update individual fields without replacing the entire connection.
+
+Implementations follow the existing `updateStore` → `updateActiveWorkbench` pattern. For example:
+
+```typescript
+const updateMidiConnection = useCallback((connId: string, updates: Partial<...>) => {
+  updateActiveWorkbench(wb => ({
+    ...wb,
+    midiConnections: (wb.midiConnections || []).map(c =>
+      c.id === connId ? { ...c, ...updates } : c
+    ),
+  }));
+}, [updateActiveWorkbench]);
+```
+
+---
+
+## Step 3: `midiUtils.ts`
+
+```typescript
+import { Jack } from './transformers';
+import { MidiConnection } from '../types/connections';
+import { ConnectionValidation, ConnectionWarning } from './connectionValidation';
+
+// Jack filtering helpers
+export function getMidiInputJacks(row: { jacks: Jack[] }): Jack[]
+  // category === 'midi' && (direction === 'input' || direction === 'bidirectional')
+
+export function getMidiOutputJacks(row: { jacks: Jack[] }): Jack[]
+  // category === 'midi' && (direction === 'output' || direction === 'bidirectional')
+
+export function hasMidiJacks(row: { jacks: Jack[] }): boolean
+  // any jack with category === 'midi'
+
+// Connector type helpers
+export function isTrsMidiConnector(connectorType: string | null): boolean
+  // true if connector_type contains '3.5mm' or 'TRS' (case-insensitive)
+
+export function is5PinDinConnector(connectorType: string | null): boolean
+  // true if connector_type contains '5-pin' or 'DIN' (case-insensitive)
+
+// Connection validation — returns structured ConnectionValidation
+// Rule keys follow 'midi:rule-name' convention:
+//
+//   midi:circular         → error (adding this would create a cycle in the connection graph)
+//   midi:din-to-trs       → warning + adapterImplication (5-pin DIN ↔ 3.5mm TRS mismatch)
+//   midi:trs-a-trs-b      → warning + adapterImplication (TRS-A ↔ TRS-B mismatch)
+//   midi:clock-conflict   → warning (existingConnections already has carriesClock=true in this chain)
+//   midi:long-chain       → info (chain depth > 4)
+//
+// Note: duplicate-channel warning is checked in MidiView at render time (not at connection
+// creation time) because channel assignment happens after the connection is created.
+export function validateMidiConnection(
+  sourceJack: { connector_type: string | null; jack_name: string | null },
+  targetJack: { connector_type: string | null; jack_name: string | null },
+  existingConnections: MidiConnection[],
+  sourceInstanceId: string,
+  targetInstanceId: string,
+): ConnectionValidation
+
+// Cycle detection (internal helper, exported for testing)
+export function wouldCreateMidiCycle(
+  sourceInstanceId: string,
+  targetInstanceId: string,
+  existingConnections: MidiConnection[],
+): boolean
+
+// Chain depth calculation — returns how many hops from the given instanceId
+// back to a root node (a node with no MIDI input connections)
+export function getChainDepth(
+  instanceId: string,
+  connections: MidiConnection[],
+): number
+```
+
+### TRS-A / TRS-B logic
+
+`trsMidiStandard` on the connection is set by the user via the channel badge after creation. During validation, if both source and target jacks are TRS MIDI connectors, the rule `midi:trs-a-trs-b` fires only when the connection already has a standard set on both sides and they differ. If either is null (unknown), fire `midi:trs-unknown` info instead.
+
+Since `trsMidiStandard` isn't a field on `Jack` in the database yet (the `jacks` table has no TRS standard column), the validation operates on the connection-level setting rather than per-jack data.
+
+---
+
+## Step 4: `MidiView.tsx`
+
+### Canvas layout
+
+- **Flow direction:** top-to-bottom — MIDI signal flows from controller down/out to connected devices, then chains further down. MIDI controllers render at **bottom center**; connected devices above arranged by chain depth.
+- **Port positions:**
+  - MIDI output port: bottom edge of card — `y ≈ CARD_HEIGHT - 4`
+  - MIDI input port: top edge of card — `y ≈ 4`
+  - Both ports centered horizontally on the card: `x = CARD_WIDTH / 2`
+- **Port spacing:** N/A — MIDI devices typically have at most one in + one out + one thru. All ports render at the horizontal center. If multiple ports exist (e.g., a thru alongside an out), offset them horizontally by ±16px.
+
+### Default positions (first render)
+
+```
+MIDI controllers: x = center, y = CANVAS_HEIGHT - 180  (bottom)
+Other devices: auto-arranged in rows above, 200px spacing
+  - Row 1 (chain depth 1): y = CANVAS_HEIGHT - 380
+  - Row 2 (chain depth 2): y = CANVAS_HEIGHT - 580
+  - Devices at same depth: spread horizontally, centered
+```
+
+Positions saved via existing `updateViewPosition` (same `VIEW_KEY = 'midi'` scoping pattern as AudioView).
+
+### Connection creation flow
+
+`PendingMidiConnection` state:
+```typescript
+interface PendingMidiConnection {
+  jackId: number;
+  instanceId: string;
+  direction: 'output' | 'input';
+}
+```
+
+1. Click an output port dot → set `pendingSource`
+2. Preview line follows mouse (same `ghostLine` pattern as AudioView/PowerView)
+3. Click an input port dot → run `validateMidiConnection` → if no errors, call `addMidiConnection` with:
+   ```typescript
+   {
+     sourceJackId, targetJackId,
+     sourceInstanceId, targetInstanceId,
+     chainIndex: getChainDepth(targetInstanceId, existingConnections),
+     midiChannel: null,
+     carriesClock: false,
+     trsMidiStandard: null,
+     acknowledgedWarnings: [],
+   }
+   ```
+4. ESC cancels pending
+
+### Channel badge overlay
+
+When a connection is selected (`selectedConnId`), render an HTML overlay (not Konva) positioned at the screen midpoint of the connection line:
+
+```
+┌─────────────────────────────┐
+│  MIDI Channel: [Omni ▾]     │
+│  [x] Carries MIDI Clock     │
+│  TRS Standard: [Unknown ▾]  │  ← only if source or target is TRS MIDI
+└─────────────────────────────┘
+```
+
+- Channel dropdown: options `['Omni', '1', '2', ... '16']`. Omni maps to `null`.
+- Clock checkbox: maps to `carriesClock`.
+- TRS Standard: hidden unless `isTrsMidiConnector(sourceJack.connector_type) || isTrsMidiConnector(targetJack.connector_type)`. Options: `['Unknown', 'TRS-A', 'TRS-B']`.
+- All changes call `updateMidiConnection(connId, { midiChannel, carriesClock, trsMidiStandard })`.
+
+Overlay positioning: use the same `viewport.worldToScreen()` transform to convert the connection midpoint world coords to screen coords, then position the overlay div with `position: absolute`.
+
+### Warning popover
+
+Same structure as AudioView/PowerView warning popovers. Calls `acknowledgeMidiWarning`.
+
+### Duplicate channel warning (render-time)
+
+After all connections render, compute a map of `{ midiChannel → instanceIds[] }`. For any channel used by more than one device on the same reachable subgraph, highlight those connections with a `warning` color and show the warning in their warning popover.
+
+This is a render-time check, not stored in connection data.
+
+### Toolbar
+
+- Zoom controls (reused `ZoomControls`)
+- Fit-all (same `fitAll` pattern as AudioView)
+- "Clear all" (button appears when connections exist, with confirm dialog)
+
+### Empty state
+
+```
+"No items with MIDI jacks in this workbench."
+```
+
+If there ARE MIDI-capable items but no connections yet:
+```
+"Click a MIDI output port to start connecting. [?] icon with hover tip"
+```
+
+---
+
+## Step 5: `ViewNav.tsx`
+
+```typescript
+{ key: 'midi', label: 'MIDI', enabled: true },  // was false
+```
+
+---
+
+## Step 6: `Workbench/index.tsx`
+
+```typescript
+import MidiView from './MidiView';
+
+// in renderActiveView():
+case 'midi':
+  return (
+    <div className="workbench__content workbench__content--canvas">
+      <MidiView rows={rows} />
+    </div>
+  );
+```
+
+---
+
+## Step 7: `index.scss` — new MIDI classes
+
+```scss
+&__midi-badge {
+  position: absolute;
+  background: #1e2a2e;
+  border: 1px solid #2a4a52;
+  border-radius: 6px;
+  padding: 8px 12px;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 20;
+  color: #c0d8e0;
+  font-size: 12px;
+}
+
+&__midi-badge-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+&__midi-badge-label {
+  color: #888;
+  white-space: nowrap;
+}
+
+&__midi-badge select {
+  background: #111;
+  border: 1px solid #334;
+  color: #c0d8e0;
+  border-radius: 3px;
+  padding: 2px 4px;
+  font-size: 11px;
+}
+```
+
+---
+
+## Step 8: `midiUtils.test.ts`
+
+- `getMidiInputJacks` — returns only category='midi' direction='input' or 'bidirectional' jacks
+- `getMidiOutputJacks` — returns only category='midi' direction='output' or 'bidirectional' jacks
+- `hasMidiJacks` — false for audio-only rows, true for rows with midi jacks
+- `isTrsMidiConnector` — true for '3.5mm TRS', false for '5-pin DIN', false for null
+- `is5PinDinConnector` — true for '5-pin DIN', false for '3.5mm TRS', false for null
+- `wouldCreateMidiCycle` — false for new unconnected items
+- `wouldCreateMidiCycle` — true when adding connection would close a loop
+- `getChainDepth` — returns 0 for a root node (no incoming connections)
+- `getChainDepth` — returns 1 for a device one hop from the root
+- `validateMidiConnection` — valid returns status 'valid'
+- `validateMidiConnection` — 5-pin DIN to 3.5mm TRS → warning + adapterImplication
+- `validateMidiConnection` — 3.5mm TRS to 3.5mm TRS (same standard or null) → valid
+- `validateMidiConnection` — null connector types handled gracefully (no warning)
+- `validateMidiConnection` — circular connection → error
+- `validateMidiConnection` — chain depth > 4 → info warning
+
+---
+
+## Verification
+
+1. `npm test` — all tests pass including new midiUtils tests (45 + ~15 new = ~60 total)
+2. `npm run web:build` — compiles cleanly (no TypeScript errors)
+3. Manual: Workbench → MIDI tab is now clickable
+4. Manual: items with MIDI jacks appear on canvas with port dots at top/bottom edges
+5. Manual: MIDI controller items render at bottom; other items above
+6. Manual: click output port → preview line follows mouse → click input port → connection created
+7. Manual: selected connection shows channel badge overlay with channel, clock, and TRS dropdowns
+8. Manual: changing channel in badge updates the connection immediately
+9. Manual: TRS standard selector appears for 3.5mm TRS connections, hidden for 5-pin DIN
+10. Manual: connector mismatch warning appears and acknowledge button works
+11. Manual: ESC cancels pending connection
+12. Manual: Delete key removes selected connection
+13. Manual: "Clear all" with confirm removes all MIDI connections

--- a/docs/plans/midi-connections-phase-3.md
+++ b/docs/plans/midi-connections-phase-3.md
@@ -52,7 +52,12 @@ export interface MidiConnection {
   chainIndex: number;                          // Position in daisy chain (0 = first from controller)
   midiChannel: number | null;                  // 1–16, null = omni
   carriesClock: boolean;                       // Whether this connection routes MIDI clock
-  trsMidiStandard: 'TRS-A' | 'TRS-B' | null;  // Only for 3.5mm TRS connectors; null = unknown
+  trsMidiStandard: 'TRS-A' | 'TRS-B' | 'tip-active' | 'ring-active' | null;
+  // Only relevant for 3.5mm TRS connectors. null = unknown.
+  // TRS-A (Type A): tip → MIDI sink, ring → MIDI source. Boss, EAE, Jackson, Korg.
+  // TRS-B (Type B): ring → MIDI sink, tip → MIDI source. Darkglass, 1010music, many modular.
+  // tip-active: voltage mode, tip carries signal. Strymon, Meris, Empress, Bondi, Alexander.
+  // ring-active: voltage mode, ring carries signal. Chase Bliss Audio.
 }
 ```
 
@@ -124,7 +129,8 @@ export function is5PinDinConnector(connectorType: string | null): boolean
 //
 //   midi:circular         → error (adding this would create a cycle in the connection graph)
 //   midi:din-to-trs       → warning + adapterImplication (5-pin DIN ↔ 3.5mm TRS mismatch)
-//   midi:trs-a-trs-b      → warning + adapterImplication (TRS-A ↔ TRS-B mismatch)
+//   midi:trs-standard-mismatch → warning + adapterImplication (any mismatch between the four
+//                                TRS standards: TRS-A, TRS-B, tip-active, ring-active)
 //   midi:clock-conflict   → warning (existingConnections already has carriesClock=true in this chain)
 //   midi:long-chain       → info (chain depth > 4)
 //
@@ -153,11 +159,13 @@ export function getChainDepth(
 ): number
 ```
 
-### TRS-A / TRS-B logic
+### TRS standard mismatch logic
 
-`trsMidiStandard` on the connection is set by the user via the channel badge after creation. During validation, if both source and target jacks are TRS MIDI connectors, the rule `midi:trs-a-trs-b` fires only when the connection already has a standard set on both sides and they differ. If either is null (unknown), fire `midi:trs-unknown` info instead.
+`trsMidiStandard` is set by the user on each connection via the channel badge after creation. During validation, if both source and target jacks are TRS MIDI connectors, `midi:trs-standard-mismatch` fires when the connection has standards set on both ends and they differ. If either is null (unknown), fire `midi:trs-unknown` info instead.
 
-Since `trsMidiStandard` isn't a field on `Jack` in the database yet (the `jacks` table has no TRS standard column), the validation operates on the connection-level setting rather than per-jack data.
+The four standards are incompatible with each other — any non-matching pair (e.g., TRS-A ↔ tip-active, TRS-B ↔ ring-active) should produce the same mismatch warning. The `adapterImplication` description should name the specific adapter needed (e.g., "TRS-A to Tip Active adapter cable").
+
+Since `trsMidiStandard` isn't a column on the `jacks` table yet (no per-jack TRS wiring field in the DB schema), the validation operates on the connection-level setting rather than per-jack data. This can be upgraded later when the schema adds a `trs_midi_standard` column to `jacks`.
 
 ---
 
@@ -225,7 +233,7 @@ When a connection is selected (`selectedConnId`), render an HTML overlay (not Ko
 
 - Channel dropdown: options `['Omni', '1', '2', ... '16']`. Omni maps to `null`.
 - Clock checkbox: maps to `carriesClock`.
-- TRS Standard: hidden unless `isTrsMidiConnector(sourceJack.connector_type) || isTrsMidiConnector(targetJack.connector_type)`. Options: `['Unknown', 'TRS-A', 'TRS-B']`.
+- TRS Standard: hidden unless `isTrsMidiConnector(sourceJack.connector_type) || isTrsMidiConnector(targetJack.connector_type)`. Options: `['Unknown', 'TRS-A', 'TRS-B', 'Tip Active', 'Ring Active']` mapping to `[null, 'TRS-A', 'TRS-B', 'tip-active', 'ring-active']`. Tip Active is used by Strymon, Meris, Empress, Bondi; Ring Active is used by Chase Bliss Audio.
 - All changes call `updateMidiConnection(connId, { midiChannel, carriesClock, trsMidiStandard })`.
 
 Overlay positioning: use the same `viewport.worldToScreen()` transform to convert the connection midpoint world coords to screen coords, then position the overlay div with `position: absolute`.
@@ -337,7 +345,11 @@ case 'midi':
 - `getChainDepth` — returns 1 for a device one hop from the root
 - `validateMidiConnection` — valid returns status 'valid'
 - `validateMidiConnection` — 5-pin DIN to 3.5mm TRS → warning + adapterImplication
-- `validateMidiConnection` — 3.5mm TRS to 3.5mm TRS (same standard or null) → valid
+- `validateMidiConnection` — TRS-A to TRS-B → mismatch warning + adapterImplication
+- `validateMidiConnection` — TRS-A to tip-active → mismatch warning + adapterImplication
+- `validateMidiConnection` — tip-active to ring-active → mismatch warning + adapterImplication
+- `validateMidiConnection` — 3.5mm TRS to 3.5mm TRS (same standard) → valid
+- `validateMidiConnection` — 3.5mm TRS to 3.5mm TRS (either null/unknown) → info only, not warning
 - `validateMidiConnection` — null connector types handled gracefully (no warning)
 - `validateMidiConnection` — circular connection → error
 - `validateMidiConnection` — chain depth > 4 → info warning

--- a/docs/plans/todo.md
+++ b/docs/plans/todo.md
@@ -9,7 +9,7 @@
 - [x] **Structured validation types** — Shared `ConnectionWarning`/`ConnectionValidation` types; migrate `powerUtils.ts` to use them (plan: `docs/plans/completed/connections-phase-1-validation-types.md`)
 - [x] **Audio connections view** — Signal chain schematic (right-to-left), virtual nodes, stereo pairs, per-item missing-data warnings, placeholder items with configurable jack configs (plan: `docs/plans/completed/audio-connections-phase-2-revised.md`)
 - [ ] **Cable routing waypoints** — Hideable cable-path layer over the Layout view (not the Audio schematic view). Full context and existing infrastructure documented in `docs/plans/audio-cable-routing-waypoints.md`. Requires: jack position data per enclosure, port dot placement in Layout view accounting for card rotation, waypoint add/move/remove UI (logic already written — see closed PR #52), length estimation feeding into shopping list.
-- [ ] **MIDI connections view** — Chain/hub topology, channel assignment, TRS-A/B detection
+- [ ] **MIDI connections view** — Chain/hub topology, channel assignment, TRS standard detection (TRS-A, TRS-B, Tip Active, Ring Active) (plan: `docs/plans/midi-connections-phase-3.md`)
 - [ ] **Control connections view** — Expression, aux switch, CV connections with polarity validation
 - [ ] **Unified shopping list** — Cables/adapters as rows in List tab alongside products, length estimation from waypoints
 - [ ] **Backend persistence** — JSONB workbench storage (deferred until user accounts exist)
@@ -52,6 +52,7 @@
 - [ ] Populate MIDI controller data (not started)
 - [ ] Populate utility data (not started)
 - [ ] Populate plug data (not started)
+- [ ] Add `trs_midi_standard` column to `jacks` table — currently the MIDI connections view stores TRS wiring configuration (TRS-A, TRS-B, Tip Active, Ring Active) at the connection level rather than per-jack. Once this column exists, validation can derive the standard from the jack data directly and pre-populate the connection's TRS setting automatically.
 
 ## 9. MIDI controller guides
 


### PR DESCRIPTION
## Summary

- Defines the MIDI connections canvas view (Phase 3 of the Connections & Cabling roadmap)
- Expands the `MidiConnection` stub with `chainIndex`, `carriesClock`, `trsMidiStandard`
- Specifies MIDI jack helpers, `validateMidiConnection()` rules (DIN↔TRS, TRS-A/B, clock conflict, long chain, cycle detection)
- Canvas layout: MIDI controllers at bottom center, connected devices above by chain depth
- Channel badge HTML overlay for channel, clock, and TRS standard after connection is created
- Covers `WorkbenchContext` CRUD, `ViewNav` enable, `index.tsx` routing, SCSS classes, and test plan (~15 new tests)

## Notes

- Builds directly on Phase 2 patterns (AudioView, `useCanvasViewport`, `ConnectionLine`, `PortDot`)
- RJM PBC/6X (seeded as product 189) has output-only MIDI — plan handles single-port devices gracefully
- TRS-A/B detection operates on connection-level metadata (no per-jack DB field yet); can be upgraded later

## Plan file

`docs/plans/midi-connections-phase-3.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)