### PR TITLE
Extract Phase 6 (cloud save) into standalone plan

### DIFF
--- a/docs/plans/connections-and-cabling.md
+++ b/docs/plans/connections-and-cabling.md
@@ -430,29 +430,7 @@ When a connector mismatch is detected on any connection:
 
 ## 7. Backend Database Design (Future Cloud Save)
 
-Workbench data is user-specific state that gets loaded whole and saved whole — there's no need to query individual connections or positions at the database level. A JSONB blob approach is simpler and maps directly to the localStorage model.
-
-**Prerequisite:** User accounts (authentication/authorization) must be implemented before cloud save is useful.
-
-### 7.1 Table
-
-```sql
-CREATE TABLE workbenches (
-    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    -- user_id INTEGER NOT NULL REFERENCES users(id),  -- Future: when auth is implemented
-    name TEXT NOT NULL,
-    data JSONB NOT NULL,              -- Complete workbench state (items, connections, positions, virtual nodes)
-    created_at TIMESTAMPTZ DEFAULT NOW(),
-    updated_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX idx_workbenches_name ON workbenches(name);
--- Future: CREATE INDEX idx_workbenches_user ON workbenches(user_id);
-```
-
-The `data` column stores the entire `Workbench` object from the frontend (minus `id`, `name`, `createdAt`, `updatedAt` which live in the table columns). This includes `items`, `viewPositions`, `viewportStates`, `powerConnections`, `audioConnections`, `midiConnections`, `controlConnections`, and `virtualNodes`.
-
-**Sync protocol:** On save, serialize the current localStorage workbench state to JSON and PUT to `/api/workbenches/{id}`. On load, GET the JSON and hydrate localStorage. Conflict resolution is last-write-wins (sufficient for single-user).
+Extracted to standalone plan: [`docs/plans/workbench-cloud-save.md`](workbench-cloud-save.md)
 
 ---
 
@@ -511,10 +489,7 @@ The `data` column stores the entire `Workbench` object from the frontend (minus 
 - **Modified files:** List tab view component
 
 ### Phase 6: Backend Persistence (deferred until user accounts exist)
-- Write migration SQL for `workbenches` table with JSONB `data` column
-- Spring Boot entity, repository, DTO, controller
-- Workbench CRUD API endpoints (GET/PUT)
-- localStorage <-> server sync
+- Extracted to standalone plan: [`docs/plans/workbench-cloud-save.md`](workbench-cloud-save.md)
 
 ---
 

--- a/docs/plans/workbench-cloud-save.md
+++ b/docs/plans/workbench-cloud-save.md
@@ -1,0 +1,46 @@
+# Workbench Cloud Save (Backend Persistence)
+
+**Status:** Design
+**Created:** 2026-02-23
+**Parent:** Extracted from `connections-and-cabling.md` Phase 6
+
+**Prerequisite:** User accounts (authentication/authorization) must be implemented before cloud save is useful.
+
+---
+
+## Context
+
+Workbench data is user-specific state that gets loaded whole and saved whole — there's no need to query individual connections or positions at the database level. A JSONB blob approach is simpler and maps directly to the localStorage model.
+
+---
+
+## Database Design
+
+### Table
+
+```sql
+CREATE TABLE workbenches (
+    id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    -- user_id INTEGER NOT NULL REFERENCES users(id),  -- Future: when auth is implemented
+    name TEXT NOT NULL,
+    data JSONB NOT NULL,              -- Complete workbench state (items, connections, positions, virtual nodes)
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_workbenches_name ON workbenches(name);
+-- Future: CREATE INDEX idx_workbenches_user ON workbenches(user_id);
+```
+
+The `data` column stores the entire `Workbench` object from the frontend (minus `id`, `name`, `createdAt`, `updatedAt` which live in the table columns). This includes `items`, `viewPositions`, `viewportStates`, `powerConnections`, `audioConnections`, `midiConnections`, `controlConnections`, and `virtualNodes`.
+
+**Sync protocol:** On save, serialize the current localStorage workbench state to JSON and PUT to `/api/workbenches/{id}`. On load, GET the JSON and hydrate localStorage. Conflict resolution is last-write-wins (sufficient for single-user).
+
+---
+
+## Implementation Checklist
+
+- Write migration SQL for `workbenches` table with JSONB `data` column
+- Spring Boot entity, repository, DTO, controller
+- Workbench CRUD API endpoints (GET/PUT)
+- localStorage <-> server sync


### PR DESCRIPTION
## Summary
- Extracts the backend persistence design (Phase 6) from `docs/plans/connections-and-cabling.md` into its own file at `docs/plans/workbench-cloud-save.md`
- Phases 1–5 of the connections & cabling plan are complete; Phase 6 is deferred until user accounts exist
- Original plan now links to the new standalone doc in both Section 7 and the Phase 6 roadmap entry

## Test plan
- [ ] Verify `docs/plans/workbench-cloud-save.md` contains the full backend design (table schema, sync protocol, implementation checklist)
- [ ] Verify `docs/plans/connections-and-cabling.md` links to the new file in Section 7 and Phase 6
- [ ] Verify no content was lost in the extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)