### PR TITLE
Fix send/return detection for intermediate nodes

### DIFF
--- a/apps/web/src/__tests__/utils/audioUtils.test.ts
+++ b/apps/web/src/__tests__/utils/audioUtils.test.ts
@@ -247,6 +247,33 @@ describe('validateAudioConnection', () => {
     expect(result.status).toBe('valid');
   });
 
+  it('returns info when new connection is between two pedals inside a send/return loop', () => {
+    // Switcher (inst-a): Send jack 10 (group_id=loop-1), Return jack 11 (group_id=loop-1)
+    // PedalA (inst-b): Input 20, Output 21
+    // PedalB (inst-c): Input 30, Output 31
+    // Existing: Switcher Send → PedalA, PedalB → Switcher Return
+    const conns = [
+      makeConn({ id: 'c1', sourceInstanceId: 'inst-a', targetInstanceId: 'inst-b', sourceJackId: 10, targetJackId: 20 }),
+      makeConn({ id: 'c2', sourceInstanceId: 'inst-c', targetInstanceId: 'inst-a', sourceJackId: 31, targetJackId: 11 }),
+    ];
+    // New: PedalA Output → PedalB Input (neither pedal has paired jacks — loop switcher is intermediate)
+    const jackLookup = new Map<number, { group_id: string | null }>([
+      [10, { group_id: 'loop-1' }],
+      [11, { group_id: 'loop-1' }],
+      [20, { group_id: null }],
+      [21, { group_id: null }],
+      [30, { group_id: null }],
+      [31, { group_id: null }],
+    ]);
+    const result = validateAudioConnection(
+      baseSourceJack, baseTargetJack, 'mono', 'mono',
+      conns, 'inst-b', 'inst-c', 21, 30, jackLookup,
+    );
+    expect(result.warnings[0].key).toBe('audio:send-return-loop');
+    expect(result.warnings[0].severity).toBe('info');
+    expect(result.status).toBe('valid');
+  });
+
   it('returns error for genuine feedback loop (no shared group_id)', () => {
     // Device A: Output jack 10 (no group_id), Input jack 11 (no group_id)
     // Device B: Input jack 20, Output jack 21

--- a/apps/web/src/utils/audioUtils.ts
+++ b/apps/web/src/utils/audioUtils.ts
@@ -24,11 +24,47 @@ export function getStereoPartner(jack: Jack, allJacks: Jack[]): Jack | undefined
 // --- Send/return loop detection ---
 
 /**
+ * Find the existing path from `fromId` to `toId` via BFS.
+ * Returns the ordered list of connections forming the path, or null if none.
+ */
+function findCyclePath(
+  fromId: string,
+  toId: string,
+  connections: AudioConnection[],
+): AudioConnection[] | null {
+  if (fromId === toId) return [];
+  const visited = new Set<string>();
+  const queue: Array<[string, AudioConnection[]]> = [[fromId, []]];
+
+  while (queue.length > 0) {
+    const [current, path] = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+
+    for (const conn of connections) {
+      if (conn.sourceInstanceId === current) {
+        const newPath = [...path, conn];
+        if (conn.targetInstanceId === toId) return newPath;
+        if (!visited.has(conn.targetInstanceId)) {
+          queue.push([conn.targetInstanceId, newPath]);
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Check if a detected cycle is actually a send/return loop topology.
  *
- * A send/return loop exists when the cycle enters and exits the same device
- * through jacks that share a group_id (a paired send/return). This works
- * regardless of how many pedals are in the chain between send and return.
+ * Traces the full cycle path and checks every node — not just the endpoints
+ * of the new connection. A send/return loop exists when any device in the
+ * cycle is entered and exited through jacks that share a group_id (a paired
+ * send/return). This works regardless of how many pedals are between send
+ * and return, and correctly identifies loops when the new connection is
+ * between two pedals inside the loop (where the loop switcher is an
+ * intermediate node).
  */
 function isSendReturnLoop(
   sourceInstanceId: string,
@@ -38,33 +74,29 @@ function isSendReturnLoop(
   existingConnections: AudioConnection[],
   jackLookup: ReadonlyMap<number, { group_id: string | null }>,
 ): boolean {
-  // Check the new connection's TARGET instance (where the cycle closes).
-  // The new connection enters this device via newTargetJackId.
-  // Look for existing connections where this device is the source (the exit point).
-  const entryJack = typeof newTargetJackId === 'number' ? jackLookup.get(newTargetJackId) : null;
-  if (entryJack?.group_id) {
-    for (const conn of existingConnections) {
-      if (conn.sourceInstanceId === targetInstanceId) {
-        const exitJack = typeof conn.sourceJackId === 'number' ? jackLookup.get(conn.sourceJackId) : null;
-        if (exitJack?.group_id && exitJack.group_id === entryJack.group_id) {
-          return true;
-        }
-      }
-    }
-  }
+  // Find the existing path that completes the cycle: target → ... → source
+  const path = findCyclePath(targetInstanceId, sourceInstanceId, existingConnections);
+  if (!path) return false;
 
-  // Check the new connection's SOURCE instance (the other closing point).
-  // The new connection exits this device via newSourceJackId.
-  // Look for existing connections where this device is the target (the entry point).
-  const exitJack = typeof newSourceJackId === 'number' ? jackLookup.get(newSourceJackId) : null;
-  if (exitJack?.group_id) {
-    for (const conn of existingConnections) {
-      if (conn.targetInstanceId === sourceInstanceId) {
-        const connEntryJack = typeof conn.targetJackId === 'number' ? jackLookup.get(conn.targetJackId) : null;
-        if (connEntryJack?.group_id && connEntryJack.group_id === exitJack.group_id) {
-          return true;
-        }
-      }
+  // Build the full cycle as ordered edges
+  type CycleEdge = { exitJackId: number | string; entryJackId: number | string };
+  const cycle: CycleEdge[] = [
+    { exitJackId: newSourceJackId, entryJackId: newTargetJackId },
+    ...path.map(c => ({ exitJackId: c.sourceJackId, entryJackId: c.targetJackId })),
+  ];
+
+  // For each node, check if its entry jack (from previous edge) and exit jack
+  // (from current edge) share a group_id — indicating a paired send/return.
+  const len = cycle.length;
+  for (let i = 0; i < len; i++) {
+    const entryJackId = cycle[(i + len - 1) % len].entryJackId;
+    const exitJackId = cycle[i].exitJackId;
+
+    const entryJack = typeof entryJackId === 'number' ? jackLookup.get(entryJackId) : null;
+    const exitJack = typeof exitJackId === 'number' ? jackLookup.get(exitJackId) : null;
+
+    if (entryJack?.group_id && exitJack?.group_id && entryJack.group_id === exitJack.group_id) {
+      return true;
     }
   }
 


### PR DESCRIPTION
## Summary
- `isSendReturnLoop` only checked the two endpoints of the new connection, missing the loop switcher when it was an intermediate node in the cycle
- Rewritten to trace the full cycle path via BFS (`findCyclePath`) and check every node for paired entry/exit jacks (shared `group_id`)
- Fixes the case where connecting two pedals inside a send/return loop incorrectly showed a feedback error

## Test plan
- [x] All 144 tests pass (added test for pedal-to-pedal connection inside a loop)
- [x] Manual: connect two pedals inside a loop switcher's send/return — should show info, not error
- [x] Manual: verify direct send→pedal→return still shows info
- [x] Manual: verify genuine A→B→A feedback still shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)