### PR TITLE
Standardize jacks.connector_type with canonical list and CHECK constraint

### DIFF
--- a/.claude/agents/reese-the-researcher.md
+++ b/.claude/agents/reese-the-researcher.md
@@ -188,7 +188,7 @@ Required fields for every jack: `product_id`, `category`, `direction`, `connecto
 |---|---|---|
 | `category` | TEXT NOT NULL | `'audio'`, `'power'`, `'midi'`, `'expression'`, `'usb'`, `'aux'` |
 | `direction` | TEXT NOT NULL | `'input'`, `'output'`, `'bidirectional'` |
-| `connector_type` | TEXT NOT NULL | `'1/4" TS'`, `'1/4" TRS'`, `'XLR'`, `'XLR Combo'`, `'5-pin DIN'`, `'3.5mm TRS'`, `'2.1mm barrel'`, `'2.5mm barrel'`, `'USB-A'`, `'USB-B'`, `'USB-C'`, `'IEC C14'`, `'Speakon'`, `'EIAJ-05'` |
+| `connector_type` | TEXT NOT NULL | Must be one of the canonical values below. A CHECK constraint enforces this. |
 | `jack_name` | TEXT | Descriptive name: `'Input L'`, `'Exp 1'`, `'Loop 1 Send'`, `'Output 1'` |
 | `position` | TEXT | `'Top'`, `'Left'`, `'Right'`, `'Bottom'`, `'Front'`, `'Back'` |
 | `voltage` | TEXT | For power jacks: `'9V'`, `'12V'`, `'18V'`, `'9-18V'`, `'9V/12V/18V'` |
@@ -198,6 +198,41 @@ Required fields for every jack: `product_id`, `category`, `direction`, `connecto
 | `is_isolated` | BOOLEAN | For power outputs |
 | `group_id` | TEXT | Links stereo pairs (`'stereo_in'`), FX loops (`'loop_1'`) |
 | `function` | TEXT | Detailed description of what this jack does |
+
+### Canonical `connector_type` Values
+
+The `jacks.connector_type` column has a CHECK constraint — only these values are accepted:
+
+| Connector | Category |
+|---|---|
+| `1/4" TS` | Audio |
+| `1/4" TRS` | Audio |
+| `3.5mm TS` | Audio / Power (some pedals use 3.5mm mono for DC input) |
+| `3.5mm TRS` | Audio |
+| `XLR` | Audio |
+| `XLR Combo` | Audio (combo jacks that accept XLR or 1/4") |
+| `6-pin XLR` | Audio/MIDI specialty |
+| `RCA` | Power (Cioks-style phono DC connectors) |
+| `5-pin DIN` | MIDI |
+| `7-pin DIN` | MIDI (phantom power capable) |
+| `2.1mm barrel` | Power |
+| `2.5mm barrel` | Power |
+| `EIAJ-05` | Power (Strymon-style DC link) |
+| `IEC C14` | Power (AC mains / kettle lead) |
+| `Hardwired` | Power (permanently attached cable, no connector) |
+| `USB-A` | USB |
+| `USB-B` | USB |
+| `USB-C` | USB |
+| `USB Mini` | USB |
+| `USB Micro` | USB |
+| `Speakon` | Speaker/load boxes |
+
+**Shared connectors disambiguated by `category`:** Both `1/4" TRS` and `3.5mm TRS` are used across multiple categories — for example, `1/4" TRS` appears as audio, expression, and MIDI (TRS MIDI). The `connector_type` describes the physical plug; the `category` field carries the semantic meaning. Do not create separate connector_type values to distinguish these uses.
+
+**Never use:**
+- `6.35mm TS` or `6.35mm TRS` — use `1/4" TS` / `1/4" TRS` instead
+- `USB Type B` or `USB Type C` — use `USB-B` / `USB-C` instead
+- Any value not in the canonical list above (the CHECK constraint will reject it)
 
 ## Product Sources (Data Provenance)
 

--- a/data/migrations/007_standardize_connector_type.sql
+++ b/data/migrations/007_standardize_connector_type.sql
@@ -1,0 +1,65 @@
+-- Migration 007: Standardize jacks.connector_type values and add CHECK constraint
+--
+-- 1. Normalizes four naming inconsistencies already in the database:
+--    '6.35mm TS'   → '1/4" TS'    (12 rows)
+--    '6.35mm TRS'  → '1/4" TRS'   (15 rows)
+--    'USB Type B'  → 'USB-B'       (3 rows)
+--    'USB Type C'  → 'USB-C'       (4 rows)
+--
+-- 2. Adds a CHECK constraint to enforce the canonical value list going forward.
+--
+-- Notes:
+--   - '1/4" TS' and '1/4" TRS' are used across multiple categories (audio, expression,
+--     aux, midi). The connector_type describes the physical plug; the category field
+--     carries the semantic meaning.
+--   - '3.5mm TRS' is similarly shared across audio, expression, and midi categories.
+--   - 'RCA' is legitimate for Cioks power supply outputs (phono-style DC connectors).
+--   - 'XLR Combo' and 'Speakon' are not yet in the database but are included
+--     preemptively: XLR Combo for DI/preamp combo jacks, Speakon for load boxes.
+
+BEGIN;
+
+-- Step 1: Normalize existing inconsistent values
+UPDATE jacks SET connector_type = '1/4" TS'  WHERE connector_type = '6.35mm TS';
+UPDATE jacks SET connector_type = '1/4" TRS' WHERE connector_type = '6.35mm TRS';
+UPDATE jacks SET connector_type = 'USB-B'    WHERE connector_type = 'USB Type B';
+UPDATE jacks SET connector_type = 'USB-C'    WHERE connector_type = 'USB Type C';
+
+-- Step 2: Add CHECK constraint enforcing the canonical list
+ALTER TABLE jacks ADD CONSTRAINT jacks_connector_type_check
+CHECK (connector_type IN (
+    -- Audio
+    '1/4" TS',
+    '1/4" TRS',
+    '3.5mm TS',
+    '3.5mm TRS',
+    'XLR',
+    'XLR Combo',
+    '6-pin XLR',
+    'RCA',
+    -- MIDI
+    '5-pin DIN',
+    '7-pin DIN',
+    -- Power
+    '2.1mm barrel',
+    '2.5mm barrel',
+    'EIAJ-05',
+    'IEC C14',
+    'Hardwired',
+    -- USB
+    'USB-A',
+    'USB-B',
+    'USB-C',
+    'USB Mini',
+    'USB Micro',
+    -- Speaker/load
+    'Speakon'
+));
+
+-- Verify: no rows should remain with non-canonical values
+SELECT connector_type, COUNT(*) AS count
+FROM jacks
+GROUP BY connector_type
+ORDER BY connector_type;
+
+COMMIT;

--- a/data/schema/gear_postgres.sql
+++ b/data/schema/gear_postgres.sql
@@ -81,14 +81,23 @@ CREATE INDEX idx_products_type ON products(product_type_id);
 CREATE TABLE jacks (
     id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     product_id INTEGER NOT NULL,          -- FK to products table
-    category TEXT NOT NULL,               -- 'Audio Input', 'Audio Output', 'MIDI In', 'MIDI Out', 'MIDI Thru',
-                                          -- 'Power Input', 'Power Output', 'Expression', 'Sidechain', 'USB', 'Aux'
-    direction TEXT NOT NULL,              -- 'Input', 'Output', 'Bidirectional'
+    category TEXT NOT NULL,               -- 'audio', 'power', 'midi', 'expression', 'usb', 'aux'
+    direction TEXT NOT NULL,              -- 'input', 'output', 'bidirectional'
     jack_name TEXT,              -- 'Input L', 'Exp 1', 'Loop 1 Send', 'Output 1'
     position TEXT,               -- 'Top', 'Left', 'Right', 'Bottom', 'Front', 'Back'
-    connector_type TEXT NOT NULL,-- '1/4" TS', '1/4" TRS', 'XLR', 'XLR Combo', '5-pin DIN',
-                                 -- '3.5mm TRS', '2.1mm barrel', '2.5mm barrel', 'USB-A',
-                                 -- 'USB-B', 'USB-C', 'IEC C14', 'Speakon'
+    connector_type TEXT NOT NULL CHECK (connector_type IN (
+                                 -- Audio
+                                 '1/4" TS', '1/4" TRS', '3.5mm TS', '3.5mm TRS',
+                                 'XLR', 'XLR Combo', '6-pin XLR', 'RCA',
+                                 -- MIDI
+                                 '5-pin DIN', '7-pin DIN',
+                                 -- Power
+                                 '2.1mm barrel', '2.5mm barrel', 'EIAJ-05', 'IEC C14', 'Hardwired',
+                                 -- USB
+                                 'USB-A', 'USB-B', 'USB-C', 'USB Mini', 'USB Micro',
+                                 -- Speaker/load
+                                 'Speakon'
+                                 )),
     impedance_ohms INTEGER,      -- For audio jacks (e.g., 1000000 for 1M ohm input)
     voltage TEXT,                -- For power jacks: '9V', '12V', '18V', '9-18V'
     current_ma INTEGER,          -- For power jacks: max current in milliamps


### PR DESCRIPTION
## Summary

- Adds a `CHECK` constraint to `jacks.connector_type` enforcing a 21-value canonical list, preventing future naming drift
- Migration `007` normalizes 34 rows with inconsistent names (`6.35mm TS/TRS` → `1/4" TS/TRS`, `USB Type B/C` → `USB-B/C`) before applying the constraint
- Updates `data/schema/gear_postgres.sql` with the inline CHECK constraint and corrects stale capitalized comments on `category` and `direction`
- Updates Reese's agent file with the full canonical table, a shared-connector disambiguation note (`1/4" TRS` and `3.5mm TRS` are shared across audio/expression/MIDI categories), and an explicit "never use" list for deprecated names

## Test plan

- [x] Run `007_standardize_connector_type.sql` against local DB — verify `SELECT` inside the transaction shows only canonical values before `COMMIT`
- [x] Confirm row counts: 12 `6.35mm TS`, 15 `6.35mm TRS`, 3 `USB Type B`, 4 `USB Type C` → all gone
- [x] Attempt to insert a jack with a non-canonical `connector_type` (e.g. `'6.35mm TS'`) — should fail with CHECK constraint violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)