### PR TITLE
Fix Reese agent schema gaps and add plug insert template

### DIFF
--- a/.claude/agents/reese-the-researcher.md
+++ b/.claude/agents/reese-the-researcher.md
@@ -264,7 +264,7 @@ VALUES (
 );
 ```
 
-**For fields on `jacks`** — `jack_id` is required (NOT NULL enforced by CHECK constraint). Use `currval('jacks_id_seq')` immediately after the jack INSERT it refers to:
+**For fields on `jacks`** — `jack_id` is required (NOT NULL enforced by CHECK constraint). **Always** use `currval('jacks_id_seq')` immediately after the jack INSERT it refers to. Never use a subquery to look up the jack by category/direction — `LIMIT 1` can silently return the wrong row if a product has multiple jacks of the same type.
 ```sql
 -- Insert the jack first
 INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)

--- a/.claude/agents/reese-the-researcher.md
+++ b/.claude/agents/reese-the-researcher.md
@@ -38,6 +38,7 @@ Read the appropriate template from `data/templates/`:
 - `insert_pedalboard.sql`
 - `insert_midi_controller.sql`
 - `insert_utility.sql`
+- `insert_plug.sql`
 
 ### Step 3: Check Manufacturer
 
@@ -180,6 +181,9 @@ If dimensions are given in inches, convert: multiply by 25.4 and round to one de
 - Audio input and output
 - Power input only if active device (omit for passive DI, passive reamp, etc.)
 
+### Plugs
+- **No jacks.** Plugs are cable connectors — they ARE the connector, not a product with ports. All connector data lives in `plug_details`, not in `jacks`.
+
 ## Jack Column Reference
 
 Required fields for every jack: `product_id`, `category`, `direction`, `connector_type`
@@ -198,6 +202,13 @@ Required fields for every jack: `product_id`, `category`, `direction`, `connecto
 | `is_isolated` | BOOLEAN | For power outputs |
 | `group_id` | TEXT | Links stereo pairs (`'stereo_in'`), FX loops (`'loop_1'`) |
 | `function` | TEXT | Detailed description of what this jack does |
+| `power_over_connector` | BOOLEAN | TRUE if jack carries power alongside signal (e.g. phantom power, bus power) |
+| `is_buffered` | BOOLEAN | TRUE if jack has a built-in buffer |
+| `buffer_switchable` | BOOLEAN | TRUE if the buffer can be toggled on/off |
+| `has_ground_lift` | BOOLEAN | TRUE if jack has a ground lift option |
+| `has_phase_invert` | BOOLEAN | TRUE if jack can invert phase/polarity |
+| `normalled_to_jack_id` | INTEGER | FK to `jacks.id` — the jack this one is normalled to |
+| `normalling_type` | TEXT | `'Normalled'`, `'Half-Normalled'`, `'Non-Normalled'`, `'Parallel'` |
 
 ### Canonical `connector_type` Values
 
@@ -236,8 +247,9 @@ The `jacks.connector_type` column has a CHECK constraint — only these values a
 
 ## Product Sources (Data Provenance)
 
-For every field populated from an external source, include a `product_sources` INSERT:
+For every field populated from an external source, include a `product_sources` INSERT.
 
+**For fields on `products`, detail tables, or `product_compatibility`:**
 ```sql
 INSERT INTO product_sources (product_id, table_name, field_name, source_type, source_url, reliability, value_recorded, accessed_at)
 VALUES (
@@ -252,9 +264,30 @@ VALUES (
 );
 ```
 
-**source_type values:** `'manufacturer_website'`, `'manufacturer_manual'`, `'manufacturer_direct'`, `'major_retailer'`, `'community_database'`, `'review_site'`, `'user_submission'`, `'other'`
+**For fields on `jacks`** — `jack_id` is required (NOT NULL enforced by CHECK constraint). Use `currval('jacks_id_seq')` immediately after the jack INSERT it refers to:
+```sql
+-- Insert the jack first
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 100, 'Center Negative');
 
-When `table_name = 'jacks'`, `jack_id` is required and must NOT be NULL. For all other table names, `jack_id` must be NULL.
+-- Then record provenance for fields sourced from external data
+INSERT INTO product_sources (product_id, jack_id, table_name, field_name, source_type, source_url, reliability, value_recorded, accessed_at)
+VALUES (
+    currval('products_id_seq'),
+    currval('jacks_id_seq'),  -- must reference the jack just inserted
+    'jacks',
+    'current_ma',
+    'major_retailer',
+    'https://www.sweetwater.com/...',
+    'Medium',
+    '100mA',
+    CURRENT_DATE
+);
+```
+
+`jack_id` must be NULL for all non-jack table names, and must NOT be NULL when `table_name = 'jacks'`. The schema enforces this with a CHECK constraint that will reject the insert if violated.
+
+**source_type values:** `'manufacturer_website'`, `'manufacturer_manual'`, `'manufacturer_direct'`, `'major_retailer'`, `'community_database'`, `'review_site'`, `'user_submission'`, `'other'`
 
 ## CHECK Constraints Quick Reference
 

--- a/data/templates/insert_midi_controller.sql
+++ b/data/templates/insert_midi_controller.sql
@@ -167,4 +167,7 @@ VALUES (currval('products_id_seq'), 'midi', 'output', '{{midi_out_connector}}', 
 --     {{verified}}
 -- );
 
+-- ─── UPDATE RESEARCH TIMESTAMP ───────────────────────────────────────────────
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
 COMMIT;

--- a/data/templates/insert_pedal.sql
+++ b/data/templates/insert_pedal.sql
@@ -168,4 +168,7 @@ VALUES (currval('products_id_seq'), 'audio', 'output', '{{audio_out_connector}}'
 --     {{verified}}                 -- TRUE/FALSE
 -- );
 
+-- ─── UPDATE RESEARCH TIMESTAMP ───────────────────────────────────────────────
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
 COMMIT;

--- a/data/templates/insert_pedalboard.sql
+++ b/data/templates/insert_pedalboard.sql
@@ -123,4 +123,7 @@ INSERT INTO pedalboard_details (
 --     {{verified}}
 -- );
 
+-- ─── UPDATE RESEARCH TIMESTAMP ───────────────────────────────────────────────
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
 COMMIT;

--- a/data/templates/insert_plug.sql
+++ b/data/templates/insert_plug.sql
@@ -1,0 +1,106 @@
+-- =============================================================================
+-- INSERT TEMPLATE: PLUG
+-- =============================================================================
+-- Product type ID: 6
+--
+-- Usage: Fill in all {{placeholder}} values with researched data.
+-- For unknown/unfound values, use NULL (not 0 or empty string).
+-- Wrap the entire insert in a transaction so all tables succeed or fail together.
+--
+-- Plugs are physical cable connectors (patch, instrument, power, MIDI, USB) used
+-- for layout planning — specifically to model how much space a plug occupies on
+-- a pedalboard. They do NOT have jacks (they ARE a connector, not a product with
+-- ports). Dimensional data is the primary purpose of this product type.
+--
+-- Key measurements:
+--   plug_width_mm  — width of plug housing, parallel to the pedal face
+--   plug_depth_mm  — how far the plug protrudes from the jack (perpendicular to pedal face)
+--   plug_height_mm — height of plug housing, vertical
+--
+-- Before running: verify the manufacturer exists with:
+--   SELECT id, name FROM manufacturers WHERE name ILIKE '%{{manufacturer_name}}%';
+-- =============================================================================
+
+BEGIN;
+
+-- ─── MANUFACTURER (uncomment if new) ────────────────────────────────────────
+-- INSERT INTO manufacturers (name, country, founded, status, specialty, website, notes)
+-- VALUES (
+--     '{{manufacturer_name}}',
+--     '{{country}}',
+--     '{{founded}}',
+--     '{{status}}',                -- 'Active', 'Defunct', 'Discontinued', 'Unknown'
+--     '{{specialty}}',
+--     '{{website}}',
+--     '{{notes}}'
+-- );
+
+-- ─── PRODUCT ────────────────────────────────────────────────────────────────
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    color_options, in_production,
+    width_mm, depth_mm, height_mm, weight_grams,
+    msrp_cents, product_page, instruction_manual,
+    description, tags, data_reliability, notes
+) VALUES (
+    {{manufacturer_id}},            -- FK to manufacturers.id
+    6,                              -- product_type_id = plug
+    '{{model}}',                    -- e.g., 'Solderless Right Angle 1/4" TS'
+    {{color_options}},              -- e.g., 'Black, Silver' or NULL
+    {{in_production}},              -- TRUE or FALSE
+    {{width_mm}},                   -- overall plug+cable-exit width in mm or NULL
+    {{depth_mm}},                   -- overall depth from jack face in mm or NULL
+    {{height_mm}},                  -- overall height in mm or NULL
+    {{weight_grams}},               -- grams or NULL (often not published)
+    {{msrp_cents}},                 -- cents or NULL — price per plug, not per pack
+    {{product_page}},               -- URL or NULL
+    {{instruction_manual}},         -- URL or NULL (rarely exists for plugs)
+    {{description}},                -- e.g., 'Low-profile right-angle patch cable plug' or NULL
+    {{tags}},                       -- e.g., 'solderless, right-angle, patch' or NULL
+    '{{data_reliability}}',         -- 'High', 'Medium', or 'Low'
+    {{notes}}                       -- Internal data curation notes or NULL
+);
+
+-- ─── PLUG DETAILS ───────────────────────────────────────────────────────────
+INSERT INTO plug_details (
+    product_id,
+    plug_type, connector_type,
+    is_right_angle, is_pancake,
+    plug_width_mm, plug_depth_mm, plug_height_mm,
+    cable_exit_direction,
+    is_solderless, housing_material, has_locking_mechanism
+) VALUES (
+    currval('products_id_seq'),
+    '{{plug_type}}',                -- REQUIRED: 'patch', 'instrument', 'power', 'midi', 'usb'
+    '{{connector_type}}',           -- REQUIRED: use canonical values where applicable (see below)
+                                    -- Audio/instrument: '1/4" TS', '1/4" TRS', 'XLR', '3.5mm TS', '3.5mm TRS', '3.5mm TRRS'
+                                    -- Power: '2.1mm barrel', '2.5mm barrel', 'EIAJ-05', 'IEC C14'
+                                    -- MIDI: '5-pin DIN', '7-pin DIN', '3.5mm TRS'
+                                    -- USB: 'USB-A', 'USB-B', 'USB-C', 'USB Mini', 'USB Micro'
+    {{is_right_angle}},             -- TRUE if plug exits at 90° angle to jack
+    {{is_pancake}},                 -- TRUE if flat/low-profile design
+    {{plug_width_mm}},              -- width of plug housing in mm or NULL
+    {{plug_depth_mm}},              -- how far plug protrudes from jack in mm or NULL
+    {{plug_height_mm}},             -- height of plug housing in mm or NULL
+    {{cable_exit_direction}},       -- 'straight', 'up', 'down', 'side' or NULL
+    {{is_solderless}},              -- TRUE for solderless systems (Evidence Audio, Lava, etc.)
+    {{housing_material}},           -- 'Metal', 'Plastic' or NULL
+    {{has_locking_mechanism}}       -- TRUE if has twist-lock or other secure connection
+);
+
+-- ─── PRODUCT COMPATIBILITY (uncomment if applicable) ────────────────────────
+-- Use this to record known compatibility with specific cable systems or products.
+-- INSERT INTO product_compatibility (product_a_id, product_b_id, compatibility_type, notes, source, verified)
+-- VALUES (
+--     currval('products_id_seq'),
+--     {{related_product_id}},
+--     '{{compatibility_type}}',    -- 'Accessory', 'Replacement'
+--     '{{compatibility_notes}}',
+--     '{{compatibility_source}}',
+--     {{verified}}
+-- );
+
+-- ─── UPDATE RESEARCH TIMESTAMP ───────────────────────────────────────────────
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+COMMIT;

--- a/data/templates/insert_power_supply.sql
+++ b/data/templates/insert_power_supply.sql
@@ -140,4 +140,7 @@ VALUES (currval('products_id_seq'), 'power', 'output', '{{out1_connector}}', '{{
 --     {{verified}}
 -- );
 
+-- ─── UPDATE RESEARCH TIMESTAMP ───────────────────────────────────────────────
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
 COMMIT;

--- a/data/templates/insert_utility.sql
+++ b/data/templates/insert_utility.sql
@@ -148,4 +148,7 @@ VALUES (currval('products_id_seq'), 'audio', 'output', '{{audio_out_connector}}'
 --     {{verified}}
 -- );
 
+-- ─── UPDATE RESEARCH TIMESTAMP ───────────────────────────────────────────────
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
 COMMIT;


### PR DESCRIPTION
## Summary

- **`product_sources` jack example** — added proper two-step pattern showing `currval('jacks_id_seq')` immediately after each jack INSERT; without this Reese would produce inserts that violate the schema's `jack_id NOT NULL` CHECK constraint for jack-level provenance records
- **Seven undocumented `jacks` columns** — added to Jack Column Reference: `power_over_connector`, `is_buffered`, `buffer_switchable`, `has_ground_lift`, `has_phase_invert`, `normalled_to_jack_id`, `normalling_type`
- **`insert_plug.sql`** — new insert template for plug/connector products (product_type_id = 6); includes note that plugs have no jacks entries since they ARE connectors, not products with ports
- **Reese Step 2 + Jack Requirements** — updated to reference `insert_plug.sql` and document that plugs skip the jacks section
- **`last_researched_at` update** — all five existing templates were missing the `UPDATE products SET last_researched_at` line at the end; added to all, consistent with the new plug template

## Test plan

- [x] Ask Reese to add a plug product — verify it reads `insert_plug.sql` and produces no jacks INSERTs
- [x] Ask Reese to add any product — verify `product_sources` rows for jack fields use `currval('jacks_id_seq')` for `jack_id`
- [x] Verify all six templates end with the `last_researched_at` UPDATE before `COMMIT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)