### PR TITLE
Add jacks expression/MIDI/aux columns (9.f–9.i)

### DIFF
--- a/apps/api/src/main/java/com/pedalshootout/api/dto/JackDto.java
+++ b/apps/api/src/main/java/com/pedalshootout/api/dto/JackDto.java
@@ -25,7 +25,11 @@ public record JackDto(
     Boolean hasPhaseInvert,
     Integer normalledToJackId,
     String normallingType,
-    String groupId
+    String groupId,
+    String trsMidiStandard,
+    String trsPolarity,
+    Integer potResistanceOhms,
+    String footswitchType
 ) {
     public static JackDto from(Jack j) {
         return new JackDto(
@@ -48,7 +52,11 @@ public record JackDto(
             j.getHasPhaseInvert(),
             j.getNormalledToJackId(),
             j.getNormallingType(),
-            j.getGroupId()
+            j.getGroupId(),
+            j.getTrsMidiStandard(),
+            j.getTrsPolarity(),
+            j.getPotResistanceOhms(),
+            j.getFootswitchType()
         );
     }
 }

--- a/apps/api/src/main/java/com/pedalshootout/api/entity/Jack.java
+++ b/apps/api/src/main/java/com/pedalshootout/api/entity/Jack.java
@@ -75,6 +75,18 @@ public class Jack {
     @Column(name = "group_id")
     private String groupId;
 
+    @Column(name = "trs_midi_standard")
+    private String trsMidiStandard;
+
+    @Column(name = "trs_polarity")
+    private String trsPolarity;
+
+    @Column(name = "pot_resistance_ohms")
+    private Integer potResistanceOhms;
+
+    @Column(name = "footswitch_type")
+    private String footswitchType;
+
     public Jack() {}
 
     // --- Getters ---
@@ -99,4 +111,8 @@ public class Jack {
     public Integer getNormalledToJackId() { return normalledToJackId; }
     public String getNormallingType() { return normallingType; }
     public String getGroupId() { return groupId; }
+    public String getTrsMidiStandard() { return trsMidiStandard; }
+    public String getTrsPolarity() { return trsPolarity; }
+    public Integer getPotResistanceOhms() { return potResistanceOhms; }
+    public String getFootswitchType() { return footswitchType; }
 }

--- a/apps/web/src/types/api.ts
+++ b/apps/web/src/types/api.ts
@@ -19,6 +19,10 @@ export interface JackApiResponse {
   normalledToJackId: number | null;
   normallingType: string | null;
   groupId: string | null;
+  trsMidiStandard: string | null;
+  trsPolarity: string | null;
+  potResistanceOhms: number | null;
+  footswitchType: string | null;
 }
 
 export interface PedalDetailApiResponse {

--- a/data/migrations/008_add_jacks_expression_midi_columns.sql
+++ b/data/migrations/008_add_jacks_expression_midi_columns.sql
@@ -1,0 +1,22 @@
+-- Migration 008: Add TRS MIDI standard, TRS polarity, pot resistance, and footswitch type to jacks
+--
+-- These columns close schema gaps identified during Control and MIDI connections development:
+--   trs_midi_standard (9.f) — enables auto-detection of TRS-A vs TRS-B in MIDI connections view
+--   trs_polarity (9.g)      — enables auto-detection of expression polarity mismatches (tip-active vs ring-active)
+--   pot_resistance_ohms (9.h) — enables resistance compatibility warnings (10K vs 25K Ohm expression pedals)
+--   footswitch_type (9.i)   — enables aux/toe-switch type validation (momentary vs latching)
+--
+-- All columns are nullable — only populated for the relevant jack categories.
+
+BEGIN;
+
+ALTER TABLE jacks
+    ADD COLUMN trs_midi_standard TEXT
+        CHECK (trs_midi_standard IN ('TRS-A', 'TRS-B', 'Tip Active', 'Ring Active')),
+    ADD COLUMN trs_polarity TEXT
+        CHECK (trs_polarity IN ('tip-active', 'ring-active')),
+    ADD COLUMN pot_resistance_ohms INTEGER,
+    ADD COLUMN footswitch_type TEXT
+        CHECK (footswitch_type IN ('momentary', 'latching'));
+
+COMMIT;

--- a/data/schema/gear_postgres.sql
+++ b/data/schema/gear_postgres.sql
@@ -113,6 +113,10 @@ CREATE TABLE jacks (
     normalling_type TEXT,                        -- 'Normalled', 'Half-Normalled', 'Non-Normalled', 'Parallel'
     group_id TEXT,               -- Links stereo pairs ('stereo_in'), FX loops ('loop_1'),
                                  -- or related jacks together
+    trs_midi_standard TEXT CHECK (trs_midi_standard IN ('TRS-A', 'TRS-B', 'Tip Active', 'Ring Active')),
+    trs_polarity TEXT CHECK (trs_polarity IN ('tip-active', 'ring-active')),
+    pot_resistance_ohms INTEGER,                                                    -- For expression jacks (e.g., 10000 for 10K Ohm)
+    footswitch_type TEXT CHECK (footswitch_type IN ('momentary', 'latching')),     -- For aux/toe-switch jacks
 
     FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
     FOREIGN KEY (normalled_to_jack_id) REFERENCES jacks(id) ON DELETE SET NULL

--- a/docs/plans/jacks-expression-midi-columns.md
+++ b/docs/plans/jacks-expression-midi-columns.md
@@ -1,0 +1,30 @@
+# Plan: Add Expression/MIDI/Aux Jack Columns (9.f–9.i)
+
+## Context
+
+Four schema gaps in the `jacks` table were identified during Control and MIDI connections development:
+- **9.f** — `trs_midi_standard`: MIDI TRS wiring standard per-jack, enabling the MIDI connections view to auto-detect TRS-A vs TRS-B instead of requiring the user to configure it on the connection.
+- **9.g** — `trs_polarity`: Expression jack tip-active vs ring-active, enabling the Control view to auto-detect polarity mismatches (e.g., Mission Engineering vs Chase Bliss).
+- **9.h** — `pot_resistance_ohms`: Expression pedal potentiometer resistance, enabling resistance compatibility warnings (10K vs 25K Ohm mismatches).
+- **9.i** — `footswitch_type`: Momentary vs latching per aux/toe-switch jack, enabling the Control view to validate switch compatibility.
+
+All four are nullable columns on the `jacks` table — purely additive, no data migration needed. Batched into a single migration file.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `data/migrations/008_add_jacks_expression_midi_columns.sql` | New migration — ALTER TABLE with CHECK constraints |
+| `data/schema/gear_postgres.sql` | Added 4 columns to jacks CREATE TABLE block |
+| `apps/api/src/main/java/com/pedalshootout/api/entity/Jack.java` | Added 4 fields + getters |
+| `apps/api/src/main/java/com/pedalshootout/api/dto/JackDto.java` | Added 4 params to record + from() |
+| `apps/web/src/types/api.ts` | Added 4 fields to JackApiResponse |
+
+## New Columns
+
+| Column | Type | CHECK Constraint | Applies to |
+|---|---|---|---|
+| `trs_midi_standard` | TEXT | `'TRS-A', 'TRS-B', 'Tip Active', 'Ring Active'` | MIDI jacks |
+| `trs_polarity` | TEXT | `'tip-active', 'ring-active'` | Expression jacks |
+| `pot_resistance_ohms` | INTEGER | none | Expression jacks |
+| `footswitch_type` | TEXT | `'momentary', 'latching'` | Aux/toe-switch jacks |


### PR DESCRIPTION
## Summary

- Adds plan doc for four new nullable columns on the `jacks` table, closing schema gaps identified during Control and MIDI connections development
- `trs_midi_standard` — TRS-A/B detection for MIDI connections view (9.f)
- `trs_polarity` — tip/ring-active detection for Control view (9.g)
- `pot_resistance_ohms` — expression pedal resistance compatibility (9.h)
- `footswitch_type` — momentary vs latching validation for aux/toe-switch jacks (9.i)

## Test plan

- [x] Run migration against local DB and verify 4 columns exist on `jacks`
- [x] Verify CHECK constraints reject invalid values
- [x] Compile Spring Boot API (`./mvnw compile -q`)
- [x] Build frontend (`npm run web:build`)
- [x] Run API and frontend tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)