### PR TITLE
Fix feedback loop false positive when two switcher loops route through one device

### DIFF
--- a/apps/web/src/__tests__/utils/audioUtils.test.ts
+++ b/apps/web/src/__tests__/utils/audioUtils.test.ts
@@ -321,6 +321,45 @@ describe('validateAudioConnection', () => {
     expect(result.warnings[0].key).toBe('audio:circular-connection');
   });
 
+  it('returns info when two switcher loops both route through a single device (e.g. KoT 4-Jack)', () => {
+    // Switcher (inst-switcher): two loops, each with paired group_ids
+    //   Loop 1: Send jack 10 (group_id=loop-1), Return jack 11 (group_id=loop-1)
+    //   Loop 2: Send jack 12 (group_id=loop-2), Return jack 13 (group_id=loop-2)
+    // KoT 4-Jack (inst-kot): two audio paths sharing an internal FX insert
+    //   Input 1: jack 20 (no group_id)
+    //   Output 1 / FX Send: jack 21 (group_id=kot-loop)
+    //   Input 2 / FX Return: jack 22 (group_id=kot-loop)
+    //   Output 2: jack 23 (no group_id)
+    // Existing connections:
+    //   1. Switcher Loop1Send → KoT Input1
+    //   2. KoT Output1 → Switcher Loop1Return
+    //   3. Switcher Loop2Send → KoT Input2
+    // New connection (4th): KoT Output2 → Switcher Loop2Return
+    // This should be a valid send/return loop, not an error.
+    const conns = [
+      makeConn({ id: 'c1', sourceInstanceId: 'inst-switcher', targetInstanceId: 'inst-kot', sourceJackId: 10, targetJackId: 20 }),
+      makeConn({ id: 'c2', sourceInstanceId: 'inst-kot', targetInstanceId: 'inst-switcher', sourceJackId: 21, targetJackId: 11 }),
+      makeConn({ id: 'c3', sourceInstanceId: 'inst-switcher', targetInstanceId: 'inst-kot', sourceJackId: 12, targetJackId: 22 }),
+    ];
+    const jackLookup = new Map<number, { group_id: string | null }>([
+      [10, { group_id: 'loop-1' }],
+      [11, { group_id: 'loop-1' }],
+      [12, { group_id: 'loop-2' }],
+      [13, { group_id: 'loop-2' }],
+      [20, { group_id: null }],
+      [21, { group_id: 'kot-loop' }],
+      [22, { group_id: 'kot-loop' }],
+      [23, { group_id: null }],
+    ]);
+    const result = validateAudioConnection(
+      baseSourceJack, baseTargetJack, 'mono', 'mono',
+      conns, 'inst-kot', 'inst-switcher', 23, 13, jackLookup,
+    );
+    expect(result.warnings[0].key).toBe('audio:send-return-loop');
+    expect(result.warnings[0].severity).toBe('info');
+    expect(result.status).toBe('valid');
+  });
+
   it('returns error for cross-loop wiring (different group_ids)', () => {
     // Switcher: Loop1 Send jack 10 (group_id=loop-1), Loop2 Return jack 13 (group_id=loop-2)
     const conns = [makeConn({

--- a/apps/web/src/utils/audioUtils.ts
+++ b/apps/web/src/utils/audioUtils.ts
@@ -31,47 +31,58 @@ export function isTrsConnector(connectorType: string | null): boolean {
 // --- Send/return loop detection ---
 
 /**
- * Find the existing path from `fromId` to `toId` via BFS.
- * Returns the ordered list of connections forming the path, or null if none.
+ * Find all shortest paths from `fromId` to `toId` via BFS.
+ * Returns all paths of minimum length. Multiple shortest paths can exist when
+ * a device (e.g. a loop switcher) has multiple outgoing connections to the
+ * same target — only checking the first path found can miss valid send/return
+ * pairs when the first path happens to cross loop boundaries.
  */
-function findCyclePath(
+function findAllCyclePaths(
   fromId: string,
   toId: string,
   connections: AudioConnection[],
-): AudioConnection[] | null {
-  if (fromId === toId) return [];
-  const visited = new Set<string>();
-  const queue: Array<[string, AudioConnection[]]> = [[fromId, []]];
+): AudioConnection[][] {
+  if (fromId === toId) return [[]];
+  const results: AudioConnection[][] = [];
+  let minLength = Infinity;
+  const queue: Array<[string, AudioConnection[], Set<string>]> = [
+    [fromId, [], new Set([fromId])],
+  ];
 
   while (queue.length > 0) {
-    const [current, path] = queue.shift()!;
-    if (visited.has(current)) continue;
-    visited.add(current);
+    const [current, path, visited] = queue.shift()!;
+    if (path.length >= minLength) continue;
 
     for (const conn of connections) {
       if (conn.sourceInstanceId === current) {
         const newPath = [...path, conn];
-        if (conn.targetInstanceId === toId) return newPath;
-        if (!visited.has(conn.targetInstanceId)) {
-          queue.push([conn.targetInstanceId, newPath]);
+        if (conn.targetInstanceId === toId) {
+          minLength = newPath.length;
+          results.push(newPath);
+        } else if (!visited.has(conn.targetInstanceId)) {
+          const nextVisited = new Set(visited);
+          nextVisited.add(conn.targetInstanceId);
+          queue.push([conn.targetInstanceId, newPath, nextVisited]);
         }
       }
     }
   }
 
-  return null;
+  return results;
 }
 
 /**
  * Check if a detected cycle is actually a send/return loop topology.
  *
- * Traces the full cycle path and checks every node — not just the endpoints
- * of the new connection. A send/return loop exists when any device in the
- * cycle is entered and exited through jacks that share a group_id (a paired
- * send/return). This works regardless of how many pedals are between send
- * and return, and correctly identifies loops when the new connection is
- * between two pedals inside the loop (where the loop switcher is an
- * intermediate node).
+ * Traces all shortest cycle paths and checks every node in each — not just
+ * the endpoints of the new connection. A send/return loop exists when any
+ * device in any candidate cycle is entered and exited through jacks that
+ * share a group_id (a paired send/return).
+ *
+ * Checking all shortest paths is necessary when a device (e.g. a loop
+ * switcher) has multiple connections to the same target instance. BFS may
+ * find a path through the "wrong" loop first, which would fail the group_id
+ * check even though a valid send/return path exists through a different loop.
  */
 function isSendReturnLoop(
   sourceInstanceId: string,
@@ -81,29 +92,32 @@ function isSendReturnLoop(
   existingConnections: AudioConnection[],
   jackLookup: ReadonlyMap<number, { group_id: string | null }>,
 ): boolean {
-  // Find the existing path that completes the cycle: target → ... → source
-  const path = findCyclePath(targetInstanceId, sourceInstanceId, existingConnections);
-  if (!path) return false;
+  // Find all shortest paths that complete the cycle: target → ... → source
+  const paths = findAllCyclePaths(targetInstanceId, sourceInstanceId, existingConnections);
+  if (paths.length === 0) return false;
 
-  // Build the full cycle as ordered edges
   type CycleEdge = { exitJackId: number | string; entryJackId: number | string };
-  const cycle: CycleEdge[] = [
-    { exitJackId: newSourceJackId, entryJackId: newTargetJackId },
-    ...path.map(c => ({ exitJackId: c.sourceJackId, entryJackId: c.targetJackId })),
-  ];
 
-  // For each node, check if its entry jack (from previous edge) and exit jack
-  // (from current edge) share a group_id — indicating a paired send/return.
-  const len = cycle.length;
-  for (let i = 0; i < len; i++) {
-    const entryJackId = cycle[(i + len - 1) % len].entryJackId;
-    const exitJackId = cycle[i].exitJackId;
+  for (const path of paths) {
+    // Build the full cycle as ordered edges
+    const cycle: CycleEdge[] = [
+      { exitJackId: newSourceJackId, entryJackId: newTargetJackId },
+      ...path.map(c => ({ exitJackId: c.sourceJackId, entryJackId: c.targetJackId })),
+    ];
 
-    const entryJack = typeof entryJackId === 'number' ? jackLookup.get(entryJackId) : null;
-    const exitJack = typeof exitJackId === 'number' ? jackLookup.get(exitJackId) : null;
+    // For each node, check if its entry jack (from previous edge) and exit jack
+    // (from current edge) share a group_id — indicating a paired send/return.
+    const len = cycle.length;
+    for (let i = 0; i < len; i++) {
+      const entryJackId = cycle[(i + len - 1) % len].entryJackId;
+      const exitJackId = cycle[i].exitJackId;
 
-    if (entryJack?.group_id && exitJack?.group_id && entryJack.group_id === exitJack.group_id) {
-      return true;
+      const entryJack = typeof entryJackId === 'number' ? jackLookup.get(entryJackId) : null;
+      const exitJack = typeof exitJackId === 'number' ? jackLookup.get(exitJackId) : null;
+
+      if (entryJack?.group_id && exitJack?.group_id && entryJack.group_id === exitJack.group_id) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- `findCyclePath` returned only the first BFS path from target to source, which could be the "wrong" path when a loop switcher has two loops both patched through the same device
- Replaced with `findAllCyclePaths`, which collects all shortest-length paths
- `isSendReturnLoop` now checks each candidate path and returns true if any contains a node where entry and exit jacks share a `group_id`

## Reproducer

King of Tone (4-Jack) patched into two loops on an RJM Mastermind PBC 10:
1. PBC Loop 1 send → KoT Input 1 ✅
2. KoT Output 1 → PBC Loop 1 return ✅
3. PBC Loop 2 send → KoT Input 2 ✅
4. KoT Output 2 → PBC Loop 2 return ❌ (incorrectly flagged as feedback loop)

BFS found the Loop 1 path (PBC → KoT via Loop1Send) before the Loop 2 path. The cycle check then compared `PBC Loop2Return` (entry) against `PBC Loop1Send` (exit) — different `group_id` values — and failed. The Loop 2 path would have matched correctly.

## Test plan

- [x] New test: `returns info when two switcher loops both route through a single device (e.g. KoT 4-Jack)` covers the exact reproducer
- [x] All 152 existing tests continue to pass
- [x] Verify in the workbench: KoT 4-Jack patched into PBC Loop 1 and Loop 2 — all four connections should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)