### PR TITLE
Add Anarchy Audio pedals (migrations 023–025)

### DIFF
--- a/data/migrations/023_add_anarchy_audio_pedals.sql
+++ b/data/migrations/023_add_anarchy_audio_pedals.sql
@@ -1,0 +1,416 @@
+-- Migration 023: Add Anarchy Audio pedals (Manufacturer ID 17) - Batch 1
+-- 7 pedals: Checkmate, Reignmaker, Hereafter, Aftermath, Flutterby, Girt, Deadwoods
+--
+-- Source: https://anarchyaudioaustralia.com/effects/ (manufacturer website)
+-- Individual product page URLs not confirmed — product_page left NULL for all.
+-- MSRP converted from AUD to USD cents (1 AUD ≈ 0.70 USD, rate as of 2026-03-22).
+--
+-- Data decisions:
+-- - Hereafter: signal_type='Hybrid', bypass_type='Buffered Bypass', has_spillover=TRUE, has_analog_dry_through=TRUE
+-- - Aftermath: signal_type='Hybrid', has_analog_dry_through=TRUE (digital glitch + analog dry path)
+-- - Aftermath: effect_type='Other' (glitch modulation/delay hybrid — no closer match in schema)
+-- - Flutterby: expression jack added (TRS, confirmed from product listing)
+-- - Checkmate: circuit_type='Bluesbreaker' (described as Bluesbreaker/King of Tone style)
+-- - Deadwoods: effect_type='Fuzz' (square-wave chainsaw fuzz, HM-2/FY-2 inspired)
+-- - Reignmaker: effect_type='Gain' (high-gain distortion with 3-band EQ — not fuzz)
+-- - current_ma values from manufacturer website: most <10mA; Reignmaker/Flutterby <20mA; Hereafter/Aftermath 35mA
+--
+-- Fields not found for all pedals:
+-- - width_mm, depth_mm, height_mm: not listed on manufacturer site or any retailer
+-- - weight_grams: not listed on manufacturer site or any retailer
+-- - instruction_manual: no manual URLs found
+
+BEGIN;
+
+-- ============================================================
+-- 1. CHECKMATE
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Checkmate',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 16800,
+    NULL,
+    'Bluesbreaker/King of Tone style overdrive, boost, and distortion pedal. Successor to the Gain of Tones. Hand-wired.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, circuit_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Bluesbreaker', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'circuit_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 2. REIGNMAKER
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Reignmaker',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 16100,
+    NULL,
+    'High-gain distortion pedal with 3-band EQ. Hand-wired analog circuit.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 20, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<20mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 3. HEREAFTER
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability,
+    notes
+) VALUES (
+    17, 1, 'Hereafter',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 20900,
+    NULL,
+    'Dual-mode ambient delay/chorus pedal with analog dry path and spillover tails. Hybrid signal path.',
+    'Medium',
+    'Analog dry path with buffered bypass; spillover/trails enabled.'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    has_analog_dry_through, has_spillover,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Delay', 'Hybrid', 'Buffered Bypass', 'Mono',
+    TRUE, TRUE,
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 35, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'signal_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'has_analog_dry_through', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'has_spillover', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '35mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 4. AFTERMATH
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability,
+    notes
+) VALUES (
+    17, 1, 'Aftermath',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 20200,
+    NULL,
+    'Glitch modulation/delay hybrid pedal with analog dry path.',
+    'Medium',
+    'Hybrid signal path with analog dry through and digital glitch processing.'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    has_analog_dry_through,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Other', 'Hybrid', 'True Bypass', 'Mono',
+    TRUE,
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 35, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'signal_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'has_analog_dry_through', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '35mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 5. FLUTTERBY
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Flutterby',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 15300,
+    NULL,
+    'Vintage optical tremolo with three waveform options and expression pedal input.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Tremolo', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 20, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'expression', 'input', '1/4" TRS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<20mA', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'jacks', 'connector_type',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'expression' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'TRS', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 6. GIRT
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Girt',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 16800,
+    NULL,
+    'Multi-mode pedal covering boost, overdrive, and fuzz voices.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 7. DEADWOODS
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Deadwoods',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 15400,
+    NULL,
+    'Square-wave chainsaw fuzz inspired by HM-2 and FY-2 circuits.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Fuzz', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+COMMIT;

--- a/data/migrations/024_add_anarchy_audio_pedals_2.sql
+++ b/data/migrations/024_add_anarchy_audio_pedals_2.sql
@@ -1,0 +1,382 @@
+-- Migration 024: Add Anarchy Audio pedals (Manufacturer ID 17) - Batch 2
+-- 7 pedals: Baa Bzz, Chaos Star, Gold Class, F-Bomb, GE Powered Device,
+--           Gain of Tones (discontinued), Spring Driver (discontinued)
+--
+-- Source: https://anarchyaudioaustralia.com/effects/ (manufacturer website)
+-- Individual product page URLs not confirmed — product_page left NULL for all.
+-- MSRP converted from AUD to USD cents (1 AUD ≈ 0.70 USD, rate as of 2026-03-22).
+--
+-- Data decisions:
+-- - Baa Bzz: effect_type='Fuzz' (Roland Bee Baa-inspired high-gain fuzz)
+-- - Chaos Star: effect_type='Fuzz' (self-oscillating synth-style fuzz)
+-- - F-Bomb: effect_type='Gain' (compact overdrive/boost — not fuzz)
+-- - GE Powered Device: effect_type='Gain' (limited edition germanium booster, only 5 units)
+-- - Gold Class: effect_type='Gain' (germanium-powered overdrive/boost/tone shaper)
+-- - Gain of Tones: in_production=FALSE (discontinued 2016–2022, replaced by Checkmate)
+-- - Spring Driver: in_production=FALSE (discontinued analog spring reverb)
+-- - Gold Class, F-Bomb, GE Powered Device: msrp_cents=NULL (no price found in any source)
+-- - GE Powered Device: in_production=TRUE (listed on site as current, despite limited run)
+--
+-- Fields not found for all pedals:
+-- - width_mm, depth_mm, height_mm: not listed on manufacturer site or any retailer
+-- - weight_grams: not listed on manufacturer site or any retailer
+-- - instruction_manual: no manual URLs found
+-- - msrp_cents for Gold Class, F-Bomb, GE Powered Device: no price found
+
+BEGIN;
+
+-- ============================================================
+-- 1. BAA BZZ
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Baa Bzz',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 13900,
+    NULL,
+    'High-gain fuzz inspired by the Roland Bee Baa.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Fuzz', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 2. CHAOS STAR
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Chaos Star',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, 13300,
+    NULL,
+    'Self-oscillating synth-style fuzz pedal.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Fuzz', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'products', 'msrp_cents', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 3. GOLD CLASS
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Gold Class',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, NULL,
+    NULL,
+    'Germanium-powered overdrive, boost, and tone shaper.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 4. F-BOMB
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'F-Bomb',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, NULL,
+    NULL,
+    'Compact overdrive and boost pedal.',
+    'Medium'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 5. GE POWERED DEVICE
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability,
+    notes
+) VALUES (
+    17, 1, 'GE Powered Device',
+    TRUE,
+    NULL, NULL, NULL,
+    NULL, NULL,
+    NULL,
+    'Limited edition germanium booster. Only 5 units produced.',
+    'Medium',
+    'Extremely limited run (5 units). Listed as current on manufacturer site as of 2026-03-22 but likely sold out.'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', 10, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22'),
+    (currval('products_id_seq'), 'pedal_details', 'bypass_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'High', '2026-03-22');
+
+INSERT INTO product_sources (product_id, table_name, field_name, jack_id, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'jacks', 'current_ma',
+     (SELECT id FROM jacks WHERE product_id = currval('products_id_seq') AND category = 'power' AND direction = 'input'),
+     'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', '<10mA', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 6. GAIN OF TONES (DISCONTINUED)
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Gain of Tones',
+    FALSE,
+    NULL, NULL, NULL,
+    NULL, NULL,
+    NULL,
+    'Discontinued overdrive pedal (2016–2022). Replaced by the Checkmate.',
+    'Low'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Gain', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', NULL, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'Medium', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+-- ============================================================
+-- 7. SPRING DRIVER (DISCONTINUED)
+-- ============================================================
+INSERT INTO products (
+    manufacturer_id, product_type_id, model,
+    in_production,
+    width_mm, depth_mm, height_mm,
+    weight_grams, msrp_cents,
+    product_page,
+    description, data_reliability
+) VALUES (
+    17, 1, 'Spring Driver',
+    FALSE,
+    NULL, NULL, NULL,
+    NULL, NULL,
+    NULL,
+    'Discontinued analog spring reverb pedal.',
+    'Low'
+);
+
+INSERT INTO pedal_details (
+    product_id,
+    effect_type, signal_type, bypass_type, mono_stereo,
+    battery_capable
+) VALUES (
+    currval('products_id_seq'),
+    'Reverb', 'Analog', 'True Bypass', 'Mono',
+    FALSE
+);
+
+INSERT INTO jacks (product_id, category, direction, connector_type, voltage, current_ma, polarity)
+VALUES (currval('products_id_seq'), 'power', 'input', '2.1mm barrel', '9V', NULL, 'Center Negative');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'input', '1/4" TS');
+
+INSERT INTO jacks (product_id, category, direction, connector_type)
+VALUES (currval('products_id_seq'), 'audio', 'output', '1/4" TS');
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, reliability, accessed_at)
+VALUES
+    (currval('products_id_seq'), 'pedal_details', 'effect_type', 'https://anarchyaudioaustralia.com/effects/', 'manufacturer_website', 'Medium', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE id = currval('products_id_seq');
+
+COMMIT;

--- a/data/migrations/025_add_anarchy_audio_dimensions.sql
+++ b/data/migrations/025_add_anarchy_audio_dimensions.sql
@@ -1,0 +1,167 @@
+-- Migration 025: Add dimensions and product_page URLs for Anarchy Audio pedals (Manufacturer ID 17)
+-- Source: individual product pages at anarchyaudioaustralia.com/effects/
+-- Dimensions format from figcaption: "WIDTHmm x DEPTHmm" (width x depth)
+-- height_mm not listed on any product page — remains NULL
+--
+-- No dimensions found for:
+-- - GE Powered Device: page exists but no spec data listed
+-- - Gain of Tones: no product page (discontinued, blog post only)
+-- - Spring Driver: no product page found
+
+BEGIN;
+
+-- Gold Class: 60mm x 112mm
+UPDATE products SET
+    width_mm = 60,
+    depth_mm = 112,
+    product_page = 'https://anarchyaudioaustralia.com/effects/goldclass/'
+WHERE manufacturer_id = 17 AND model = 'Gold Class';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Gold Class'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/goldclass/', 'manufacturer_website', '60mm x 112mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Gold Class'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/goldclass/', 'manufacturer_website', '60mm x 112mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Gold Class'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/goldclass/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/goldclass/', 'High', '2026-03-22');
+
+-- Checkmate: 66mm x 122mm
+UPDATE products SET
+    width_mm = 66,
+    depth_mm = 122,
+    product_page = 'https://anarchyaudioaustralia.com/effects/checkmate/'
+WHERE manufacturer_id = 17 AND model = 'Checkmate';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Checkmate'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/checkmate/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Checkmate'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/checkmate/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Checkmate'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/checkmate/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/checkmate/', 'High', '2026-03-22');
+
+-- Reignmaker: 66mm x 122mm
+UPDATE products SET
+    width_mm = 66,
+    depth_mm = 122,
+    product_page = 'https://anarchyaudioaustralia.com/effects/reignmaker/'
+WHERE manufacturer_id = 17 AND model = 'Reignmaker';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Reignmaker'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/reignmaker/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Reignmaker'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/reignmaker/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Reignmaker'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/reignmaker/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/reignmaker/', 'High', '2026-03-22');
+
+-- Hereafter: 120mm x 94mm
+UPDATE products SET
+    width_mm = 120,
+    depth_mm = 94,
+    product_page = 'https://anarchyaudioaustralia.com/effects/hereafter/'
+WHERE manufacturer_id = 17 AND model = 'Hereafter';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Hereafter'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/hereafter/', 'manufacturer_website', '120mm x 94mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Hereafter'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/hereafter/', 'manufacturer_website', '120mm x 94mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Hereafter'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/hereafter/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/hereafter/', 'High', '2026-03-22');
+
+-- Aftermath: 120mm x 94mm
+UPDATE products SET
+    width_mm = 120,
+    depth_mm = 94,
+    product_page = 'https://anarchyaudioaustralia.com/effects/aftermath/'
+WHERE manufacturer_id = 17 AND model = 'Aftermath';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Aftermath'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/aftermath/', 'manufacturer_website', '120mm x 94mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Aftermath'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/aftermath/', 'manufacturer_website', '120mm x 94mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Aftermath'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/aftermath/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/aftermath/', 'High', '2026-03-22');
+
+-- Flutterby: 66mm x 122mm
+UPDATE products SET
+    width_mm = 66,
+    depth_mm = 122,
+    product_page = 'https://anarchyaudioaustralia.com/effects/flutterby/'
+WHERE manufacturer_id = 17 AND model = 'Flutterby';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Flutterby'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/flutterby/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Flutterby'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/flutterby/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Flutterby'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/flutterby/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/flutterby/', 'High', '2026-03-22');
+
+-- Girt: 66mm x 122mm
+UPDATE products SET
+    width_mm = 66,
+    depth_mm = 122,
+    product_page = 'https://anarchyaudioaustralia.com/effects/girt/'
+WHERE manufacturer_id = 17 AND model = 'Girt';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Girt'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/girt/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Girt'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/girt/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Girt'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/girt/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/girt/', 'High', '2026-03-22');
+
+-- Deadwoods: 66mm x 122mm (canonical URL: /effects/deadwoods-2/)
+UPDATE products SET
+    width_mm = 66,
+    depth_mm = 122,
+    product_page = 'https://anarchyaudioaustralia.com/effects/deadwoods-2/'
+WHERE manufacturer_id = 17 AND model = 'Deadwoods';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Deadwoods'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/deadwoods-2/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Deadwoods'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/deadwoods-2/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Deadwoods'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/deadwoods-2/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/deadwoods-2/', 'High', '2026-03-22');
+
+-- Baa Bzz: 66mm x 122mm
+UPDATE products SET
+    width_mm = 66,
+    depth_mm = 122,
+    product_page = 'https://anarchyaudioaustralia.com/effects/baabzz/'
+WHERE manufacturer_id = 17 AND model = 'Baa Bzz';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Baa Bzz'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/baabzz/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Baa Bzz'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/baabzz/', 'manufacturer_website', '66mm x 122mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Baa Bzz'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/baabzz/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/baabzz/', 'High', '2026-03-22');
+
+-- Chaos Star: 60mm x 112mm
+UPDATE products SET
+    width_mm = 60,
+    depth_mm = 112,
+    product_page = 'https://anarchyaudioaustralia.com/effects/chaos-star/'
+WHERE manufacturer_id = 17 AND model = 'Chaos Star';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Chaos Star'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/chaos-star/', 'manufacturer_website', '60mm x 112mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Chaos Star'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/chaos-star/', 'manufacturer_website', '60mm x 112mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'Chaos Star'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/chaos-star/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/chaos-star/', 'High', '2026-03-22');
+
+-- F-Bomb: 60mm x 112mm
+UPDATE products SET
+    width_mm = 60,
+    depth_mm = 112,
+    product_page = 'https://anarchyaudioaustralia.com/effects/f-bomb/'
+WHERE manufacturer_id = 17 AND model = 'F-Bomb';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'F-Bomb'), 'products', 'width_mm', 'https://anarchyaudioaustralia.com/effects/f-bomb/', 'manufacturer_website', '60mm x 112mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'F-Bomb'), 'products', 'depth_mm', 'https://anarchyaudioaustralia.com/effects/f-bomb/', 'manufacturer_website', '60mm x 112mm', 'High', '2026-03-22'),
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'F-Bomb'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/f-bomb/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/f-bomb/', 'High', '2026-03-22');
+
+-- GE Powered Device: product page confirmed, no dimensions listed
+UPDATE products SET
+    product_page = 'https://anarchyaudioaustralia.com/effects/ge-powered-device/'
+WHERE manufacturer_id = 17 AND model = 'GE Powered Device';
+
+INSERT INTO product_sources (product_id, table_name, field_name, source_url, source_type, value_recorded, reliability, accessed_at)
+VALUES
+    ((SELECT id FROM products WHERE manufacturer_id = 17 AND model = 'GE Powered Device'), 'products', 'product_page', 'https://anarchyaudioaustralia.com/effects/ge-powered-device/', 'manufacturer_website', 'https://anarchyaudioaustralia.com/effects/ge-powered-device/', 'High', '2026-03-22');
+
+UPDATE products SET last_researched_at = CURRENT_DATE WHERE manufacturer_id = 17;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- 14 Anarchy Audio pedals added across 3 migrations (manufacturer_id = 17)
- 12 current production + 2 discontinued (Gain of Tones, Spring Driver)
- Dimensions sourced from manufacturer product pages for 11 of 14 pedals
- All product_page URLs verified by fetch

## Pedals Added

| Model | Effect | MSRP (USD) |
|---|---|---|
| Checkmate | Gain | $168 |
| Reignmaker | Gain | $161 |
| Hereafter | Delay | $209 |
| Aftermath | Other | $202 |
| Flutterby | Tremolo | $153 |
| Girt | Gain | $168 |
| Deadwoods | Fuzz | $154 |
| Baa Bzz | Fuzz | $139 |
| Chaos Star | Fuzz | $133 |
| Gold Class | Gain | — |
| F-Bomb | Gain | — |
| GE Powered Device | Gain | — |
| Gain of Tones *(discontinued)* | Gain | — |
| Spring Driver *(discontinued)* | Reverb | — |

## Test plan

- [x] Verify migrations apply cleanly on a fresh checkout
- [x] Confirm 14 products visible in web app filtered to Anarchy Audio
- [x] Confirm dimensions display for the 11 pedals that have them

🤖 Generated with [Claude Code](https://claude.com/claude-code)