### PR TITLE
Add 'Looper' effect_type and 'Aux Switch' utility_type (migration 030)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ The schema enforces allowed values via CHECK constraints. Inserts will fail if a
 - `status`: `'Active'`, `'Defunct'`, `'Discontinued'`, `'Unknown'`
 
 **`pedal_details`**
-- `effect_type`: `'Gain'`, `'Fuzz'`, `'Compression'`, `'Delay'`, `'Reverb'`, `'Chorus'`, `'Flanger'`, `'Phaser'`, `'Tremolo'`, `'Vibrato'`, `'Rotary'`, `'Univibe'`, `'Ring Modulator'`, `'Pitch Shifter'`, `'Wah'`, `'Filter'`, `'Multi Effects'`, `'Utility'`, `'Preamp'`, `'Amp/Cab Sim'`, `'Other'`
+- `effect_type`: `'Gain'`, `'Fuzz'`, `'Compression'`, `'Delay'`, `'Reverb'`, `'Chorus'`, `'Flanger'`, `'Phaser'`, `'Tremolo'`, `'Vibrato'`, `'Rotary'`, `'Univibe'`, `'Ring Modulator'`, `'Pitch Shifter'`, `'Wah'`, `'Filter'`, `'EQ'`, `'Looper'`, `'Multi Effects'`, `'Utility'`, `'Preamp'`, `'Amp/Cab Sim'`, `'Other'`
 - `signal_type`: `'Analog'`, `'Digital'`, `'Hybrid'`
 - `bypass_type`: `'True Bypass'`, `'Buffered Bypass'`, `'Relay Bypass'`, `'DSP Bypass'`, `'Both'`
 - `mono_stereo`: `'Mono'`, `'Stereo In/Out'`, `'Mono In/Stereo Out'`
@@ -354,7 +354,7 @@ The schema enforces allowed values via CHECK constraints. Inserts will fail if a
 - `footswitch_type`: `'Momentary'`, `'Latching'`, `'Dual-Action'`, `'Mixed'`
 
 **`utility_details`**
-- `utility_type` (22 values): `'DI Box'`, `'Reamp Box'`, `'Buffer'`, `'Splitter'`, `'A/B Box'`, `'A/B/Y Box'`, `'Tuner'`, `'Volume Pedal'`, `'Expression Pedal'`, `'Noise Gate'`, `'Power Conditioner'`, `'Signal Router'`, `'Impedance Matcher'`, `'Headphone Amp'`, `'Mixer'`, `'Junction Box'`, `'Patch Bay'`, `'Mute Switch'`, `'Amp Switcher'`, `'Load Box'`, `'Line Level Converter'`, `'Other'`
+- `utility_type` (24 values): `'DI Box'`, `'Reamp Box'`, `'Buffer'`, `'Splitter'`, `'A/B Box'`, `'A/B/Y Box'`, `'Tuner'`, `'Volume Pedal'`, `'Expression Pedal'`, `'Noise Gate'`, `'Power Conditioner'`, `'Signal Router'`, `'Impedance Matcher'`, `'Headphone Amp'`, `'Mixer'`, `'Junction Box'`, `'Patch Bay'`, `'Mute Switch'`, `'Amp Switcher'`, `'Load Box'`, `'Line Level Converter'`, `'Tap Tempo'`, `'Aux Switch'`, `'Other'`
 - `signal_type`: `'Analog'`, `'Digital'`, `'Both'`
 
 **`product_compatibility`**

--- a/data/migrations/030_add_looper_effect_type_and_aux_switch_utility_type.sql
+++ b/data/migrations/030_add_looper_effect_type_and_aux_switch_utility_type.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- Migration 030: Add 'Looper' effect_type and 'Aux Switch' utility_type
+-- =============================================================================
+-- Adds two new allowed values to existing CHECK constraints:
+--   - 'Looper' to pedal_details.effect_type
+--   - 'Aux Switch' to utility_details.utility_type
+-- =============================================================================
+
+BEGIN;
+
+-- ─── pedal_details.effect_type ───────────────────────────────────────────────
+
+ALTER TABLE pedal_details DROP CONSTRAINT pedal_details_effect_type_check;
+
+ALTER TABLE pedal_details ADD CONSTRAINT pedal_details_effect_type_check
+    CHECK (effect_type IN (
+        'Gain', 'Fuzz', 'Compression', 'Delay', 'Reverb',
+        'Chorus', 'Flanger', 'Phaser', 'Tremolo', 'Vibrato',
+        'Rotary', 'Univibe', 'Ring Modulator',
+        'Pitch Shifter', 'Wah', 'Filter', 'EQ',
+        'Looper', 'Multi Effects', 'Utility', 'Preamp', 'Amp/Cab Sim', 'Other'
+    ));
+
+-- ─── utility_details.utility_type ────────────────────────────────────────────
+
+ALTER TABLE utility_details DROP CONSTRAINT utility_details_utility_type_check;
+
+ALTER TABLE utility_details ADD CONSTRAINT utility_details_utility_type_check
+    CHECK (utility_type IN (
+        'DI Box', 'Reamp Box', 'Buffer', 'Splitter', 'A/B Box', 'A/B/Y Box',
+        'Tuner', 'Volume Pedal', 'Expression Pedal', 'Noise Gate',
+        'Power Conditioner', 'Signal Router', 'Impedance Matcher',
+        'Headphone Amp', 'Mixer', 'Junction Box', 'Patch Bay',
+        'Mute Switch', 'Amp Switcher', 'Load Box', 'Line Level Converter',
+        'Tap Tempo', 'Aux Switch', 'Other'
+    ));
+
+COMMIT;

--- a/data/schema/gear_postgres.sql
+++ b/data/schema/gear_postgres.sql
@@ -140,7 +140,7 @@ CREATE TABLE pedal_details (
         'Chorus', 'Flanger', 'Phaser', 'Tremolo', 'Vibrato',
         'Rotary', 'Univibe', 'Ring Modulator',
         'Pitch Shifter', 'Wah', 'Filter', 'EQ',
-        'Multi Effects', 'Utility', 'Preamp', 'Amp/Cab Sim', 'Other'
+        'Looper', 'Multi Effects', 'Utility', 'Preamp', 'Amp/Cab Sim', 'Other'
     )),                                   -- Primary effect category
     circuit_type TEXT,            -- 'Bluesbreaker', 'Tube Screamer', 'Klon', 'RAT',
                                   -- 'Big Muff', 'Fuzz Face', 'Memory Man', etc.
@@ -336,7 +336,7 @@ CREATE TABLE utility_details (
         'Power Conditioner', 'Signal Router', 'Impedance Matcher',
         'Headphone Amp', 'Mixer', 'Junction Box', 'Patch Bay',
         'Mute Switch', 'Amp Switcher', 'Load Box', 'Line Level Converter',
-        'Tap Tempo', 'Other'
+        'Tap Tempo', 'Aux Switch', 'Other'
     )),                                   -- Specific utility category
 
     -- Signal path


### PR DESCRIPTION
## Summary
- Adds `'Looper'` to the `pedal_details.effect_type` CHECK constraint
- Adds `'Aux Switch'` to the `utility_details.utility_type` CHECK constraint
- Updates `data/schema/gear_postgres.sql` and `CLAUDE.md` to match the live constraints

## Test plan
- [ ] Migration runs cleanly via `psql -f data/migrations/030_...sql`
- [ ] `'Looper'` accepted as a valid `effect_type` in `pedal_details`
- [ ] `'Aux Switch'` accepted as a valid `utility_type` in `utility_details`
- [ ] Schema file and CLAUDE.md quick reference match the live constraints

🤖 Generated with [Claude Code](https://claude.com/claude-code)